### PR TITLE
[fix bugs] judge gremlin step by class_type instead of instance in Ir…

### DIFF
--- a/research/gaia-x/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/OpArgTransformFactory.java
+++ b/research/gaia-x/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/OpArgTransformFactory.java
@@ -5,7 +5,6 @@ import com.alibaba.graphscope.common.jna.IrCoreLibrary;
 import com.alibaba.graphscope.common.jna.type.FfiDirection;
 import com.alibaba.graphscope.common.jna.type.FfiScanOpt;
 import org.apache.tinkerpop.gremlin.process.traversal.Compare;
-import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
@@ -27,7 +26,7 @@ public class OpArgTransformFactory {
         else return FfiScanOpt.Edge;
     };
 
-    public static Function<GraphStep, List> ID_CONST = (GraphStep s1) ->
+    public static Function<GraphStep, List> CONST_IDS_FROM_STEP = (GraphStep s1) ->
             Arrays.stream(s1.getIds()).map((id) -> {
                 if (id instanceof Long) {
                     return irCoreLib.int64AsConst((Long) id);
@@ -36,7 +35,7 @@ public class OpArgTransformFactory {
                 }
             }).collect(Collectors.toList());
 
-    public static Function<List<HasContainer>, String> PREDICATE_EXPR = (List<HasContainer> containers) -> {
+    public static Function<List<HasContainer>, String> EXPR_FROM_CONTAINERS = (List<HasContainer> containers) -> {
         String expr = "";
         for (int i = 0; i < containers.size(); ++i) {
             HasContainer container = containers.get(i);
@@ -59,9 +58,9 @@ public class OpArgTransformFactory {
         return expr;
     };
 
-    public static Function<HasContainerHolder, List> EXTRACT_LABELS = (HasContainerHolder holder) -> {
+    public static Function<List<HasContainer>, List> LABELS_FROM_CONTAINERS = (List<HasContainer> containers) -> {
         List<String> labels = new ArrayList<>();
-        for (HasContainer container : holder.getHasContainers()) {
+        for (HasContainer container : containers) {
             if (container.getKey().equals(T.label.getAccessor())) {
                 Object value = container.getValue();
                 if (value instanceof String) {
@@ -78,7 +77,7 @@ public class OpArgTransformFactory {
         return labels.stream().map(k -> irCoreLib.cstrAsNameOrId(k)).collect(Collectors.toList());
     };
 
-    public static Function<VertexStep, FfiDirection> DIRECTION = (VertexStep s1) -> {
+    public static Function<VertexStep, FfiDirection> DIRECTION_FROM_STEP = (VertexStep s1) -> {
         Direction direction = s1.getDirection();
         switch (direction) {
             case IN:
@@ -92,7 +91,7 @@ public class OpArgTransformFactory {
         }
     };
 
-    public static Function<VertexStep, Boolean> IS_EDGE = (VertexStep s1) -> {
+    public static Function<VertexStep, Boolean> IS_EDGE_FROM_STEP = (VertexStep s1) -> {
         if (s1.returnsEdge()) {
             return Boolean.valueOf(true);
         } else {
@@ -100,6 +99,6 @@ public class OpArgTransformFactory {
         }
     };
 
-    public static Function<VertexStep, List> EDGE_LABELS = (VertexStep s1) ->
+    public static Function<VertexStep, List> EDGE_LABELS_FROM_STEP = (VertexStep s1) ->
             Arrays.stream(s1.getEdgeLabels()).map(k -> irCoreLib.cstrAsNameOrId(k)).collect(Collectors.toList());
 }

--- a/research/gaia-x/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/EmptyTest.java
+++ b/research/gaia-x/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/EmptyTest.java
@@ -1,0 +1,65 @@
+package com.alibaba.graphscope.gremlin;
+
+import com.alibaba.graphscope.common.intermediate.operator.ExpandOp;
+import com.alibaba.graphscope.common.intermediate.operator.ScanFusionOp;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+// test whether Optional<OpArg> in InterOp is empty when parameters in traversal is not set
+public class EmptyTest {
+    private Graph graph = TinkerFactory.createModern();
+    private GraphTraversalSource g = graph.traversal();
+
+    @Test
+    public void g_V_has_no_id_test() {
+        Traversal traversal = g.V();
+        traversal.asAdmin().applyStrategies();
+        Step step = traversal.asAdmin().getStartStep();
+        ScanFusionOp op = (ScanFusionOp) IrPlanBuidler.StepTransformFactory.TINKER_GRAPH_STEP.apply(step);
+        Assert.assertEquals(false, op.getIds().isPresent());
+    }
+
+    @Test
+    public void g_V_has_no_label_has_no_property_test() {
+        Traversal traversal = g.V();
+        traversal.asAdmin().applyStrategies();
+        Step step = traversal.asAdmin().getStartStep();
+        ScanFusionOp op = (ScanFusionOp) IrPlanBuidler.StepTransformFactory.TINKER_GRAPH_STEP.apply(step);
+        Assert.assertEquals(false, op.getPredicate().isPresent());
+        Assert.assertEquals(false, op.getLabels().isPresent());
+    }
+
+    @Test
+    public void g_V_has_label_has_no_property_test() {
+        Traversal traversal = g.V().hasLabel("person");
+        traversal.asAdmin().applyStrategies();
+        Step step = traversal.asAdmin().getStartStep();
+        ScanFusionOp op = (ScanFusionOp) IrPlanBuidler.StepTransformFactory.TINKER_GRAPH_STEP.apply(step);
+        Assert.assertEquals(false, op.getPredicate().isPresent());
+        Assert.assertEquals(true, op.getLabels().isPresent());
+    }
+
+    @Test
+    public void g_V_has_no_label_has_property_test() {
+        Traversal traversal = g.V().has("id", 1);
+        traversal.asAdmin().applyStrategies();
+        Step step = traversal.asAdmin().getStartStep();
+        ScanFusionOp op = (ScanFusionOp) IrPlanBuidler.StepTransformFactory.TINKER_GRAPH_STEP.apply(step);
+        Assert.assertEquals(true, op.getPredicate().isPresent());
+        Assert.assertEquals(false, op.getLabels().isPresent());
+    }
+
+    @Test
+    public void g_V_outE_has_no_label_test() {
+        Traversal traversal = g.V().out();
+        traversal.asAdmin().applyStrategies();
+        Step step = traversal.asAdmin().getEndStep();
+        ExpandOp op = (ExpandOp) IrPlanBuidler.StepTransformFactory.VERTEX_STEP.apply(step);
+        Assert.assertEquals(false, op.getLabels().isPresent());
+    }
+}


### PR DESCRIPTION
…PlanBuidler

            && add corner judgement when setting OpArg for each InterOpBase in StepTransformFactory

<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
1. judge gremlin step by class_type instead of instance in IrPlanBuidler
2. add corner judgement when setting OpArg for each InterOpBase in StepTransformFactory

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

