### PR TITLE
Add dedup and group in compiler

### DIFF
--- a/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
+++ b/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
@@ -193,7 +193,8 @@ traversalMethod_dedup
 	;
 
 traversalMethod_group
-	: 'group' LPAREN RPAREN (DOT traversalMethod_group_keyby)? (DOT traversalMethod_group_valueby)?
+	: 'group' LPAREN RPAREN (DOT traversalMethod_group_keyby)?
+	| 'group' LPAREN RPAREN DOT traversalMethod_group_keyby DOT traversalMethod_group_valueby
 	;
 
 traversalMethod_groupCount
@@ -208,13 +209,11 @@ traversalMethod_group_keyby
     | 'by' LPAREN traversalMethod_values (DOT traversalMethod_as)? RPAREN
     ;
 
-// group().by(...).by() infers group().by(...).by(fold())
 // group().by(...).by(fold().as("value"))
 // group().by(...).by(count())
 // group().by(...).by(count().as("value"))
 traversalMethod_group_valueby
-    : 'by' LPAREN RPAREN
-    | 'by' LPAREN traversalMethod_aggregate_func (DOT traversalMethod_as)? RPAREN
+    : 'by' LPAREN traversalMethod_aggregate_func (DOT traversalMethod_as)? RPAREN
     ;
 
 traversalMethod_aggregate_func
@@ -230,7 +229,7 @@ traversalMethod_count
 // only one argument is permitted
 // values("name")
 traversalMethod_values
-    : 'values' LPAREN NonEmptyStringLiteral RPAREN
+    : 'values' LPAREN stringLiteral RPAREN
     ;
 
 // fold()

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgAggFn.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgAggFn.java
@@ -1,0 +1,53 @@
+package com.alibaba.graphscope.common.intermediate;
+
+import com.alibaba.graphscope.common.jna.type.FfiAggOpt;
+import com.alibaba.graphscope.common.jna.type.FfiAlias;
+import com.alibaba.graphscope.common.jna.type.FfiVariable;
+import com.google.common.base.Objects;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// represent AggFn of Group Value, as a variable of GroupOp
+public class ArgAggFn {
+    private List<FfiVariable.ByValue> vars;
+    private FfiAggOpt aggregate;
+    private FfiAlias.ByValue alias;
+
+    public ArgAggFn(FfiAggOpt aggregate, FfiAlias.ByValue alias) {
+        this.aggregate = aggregate;
+        this.alias = alias;
+        this.vars = new ArrayList<>();
+    }
+
+    public void addVar(FfiVariable.ByValue var) {
+        this.vars.add(var);
+    }
+
+    public List<FfiVariable.ByValue> getVars() {
+        return vars;
+    }
+
+    public FfiAggOpt getAggregate() {
+        return aggregate;
+    }
+
+    public FfiAlias.ByValue getAlias() {
+        return alias;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ArgAggFn argAggFn = (ArgAggFn) o;
+        return Objects.equal(vars, argAggFn.vars) &&
+                aggregate == argAggFn.aggregate &&
+                Objects.equal(alias, argAggFn.alias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(vars, aggregate, alias);
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgAggFn.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgAggFn.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.common.intermediate;
 
 import com.alibaba.graphscope.common.jna.type.FfiAggOpt;

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgUtils.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgUtils.java
@@ -16,6 +16,7 @@
 
 package com.alibaba.graphscope.common.intermediate;
 
+import com.alibaba.graphscope.common.exception.OpArgIllegalException;
 import com.alibaba.graphscope.common.jna.IrCoreLibrary;
 import com.alibaba.graphscope.common.jna.type.*;
 
@@ -23,8 +24,8 @@ public class ArgUtils {
     private static IrCoreLibrary irCoreLib = IrCoreLibrary.INSTANCE;
     private static String LABEL = "~label";
     private static String ID = "~id";
-    public static String GROUP_KEYS = "~keys";
-    public static String GROUP_VALUES = "~values";
+    private static String GROUP_KEYS = "keys";
+    private static String GROUP_VALUES = "values";
 
     public static FfiNameOrId.ByValue strAsNameId(String value) {
         return irCoreLib.cstrAsNameOrId(value);
@@ -48,6 +49,19 @@ public class ArgUtils {
         }
     }
 
+    public static String getPropertyName(FfiProperty.ByValue property) {
+        switch (property.opt) {
+            case Id:
+                return ID;
+            case Label:
+                return LABEL;
+            case Key:
+                return property.key.name;
+            default:
+                throw new OpArgIllegalException(OpArgIllegalException.Cause.INVALID_TYPE, "invalid type");
+        }
+    }
+
     public static FfiVariable.ByValue asVarPropertyOnly(FfiProperty.ByValue property) {
         return irCoreLib.asVarPropertyOnly(property);
     }
@@ -64,12 +78,12 @@ public class ArgUtils {
         return ffiAlias;
     }
 
-    public static FfiAlias.ByValue groupKeysAlias() {
-        return asFfiAlias(GROUP_KEYS, false);
+    public static String groupKeys() {
+        return GROUP_KEYS;
     }
 
-    public static FfiAlias.ByValue groupValuesAlias() {
-        return asFfiAlias(GROUP_VALUES, false);
+    public static String groupValues() {
+        return GROUP_VALUES;
     }
 
     public static FfiAggFn.ByValue asFfiAggFn(ArgAggFn aggFn) {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgUtils.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/ArgUtils.java
@@ -23,6 +23,8 @@ public class ArgUtils {
     private static IrCoreLibrary irCoreLib = IrCoreLibrary.INSTANCE;
     private static String LABEL = "~label";
     private static String ID = "~id";
+    public static String GROUP_KEYS = "~keys";
+    public static String GROUP_VALUES = "~values";
 
     public static FfiNameOrId.ByValue strAsNameId(String value) {
         return irCoreLib.cstrAsNameOrId(value);
@@ -60,6 +62,20 @@ public class ArgUtils {
         ffiAlias.alias = alias;
         ffiAlias.isQueryGiven = isQueryGiven;
         return ffiAlias;
+    }
+
+    public static FfiAlias.ByValue groupKeysAlias() {
+        return asFfiAlias(GROUP_KEYS, false);
+    }
+
+    public static FfiAlias.ByValue groupValuesAlias() {
+        return asFfiAlias(GROUP_VALUES, false);
+    }
+
+    public static FfiAggFn.ByValue asFfiAggFn(ArgAggFn aggFn) {
+        FfiAggFn.ByValue ffiAggFn = irCoreLib.initAggFn(aggFn.getAggregate(), aggFn.getAlias());
+        // todo: add var
+        return ffiAggFn;
     }
 }
 

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/DedupOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/DedupOp.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.common.intermediate.operator;
 
 import java.util.Optional;

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/DedupOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/DedupOp.java
@@ -1,0 +1,21 @@
+package com.alibaba.graphscope.common.intermediate.operator;
+
+import java.util.Optional;
+
+public class DedupOp extends InterOpBase {
+    // list<FfiVariable>
+    private Optional<OpArg> dedupKeys;
+
+    public DedupOp() {
+        super();
+        dedupKeys = Optional.empty();
+    }
+
+    public Optional<OpArg> getDedupKeys() {
+        return dedupKeys;
+    }
+
+    public void setDedupKeys(OpArg dedupKeys) {
+        this.dedupKeys = Optional.of(dedupKeys);
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/GroupOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/GroupOp.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.common.intermediate.operator;
 
 import java.util.Optional;

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/GroupOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/GroupOp.java
@@ -1,0 +1,33 @@
+package com.alibaba.graphscope.common.intermediate.operator;
+
+import java.util.Optional;
+
+public class GroupOp extends InterOpBase {
+    // List of Pair<FfiVariable, FfiAlias>
+    private Optional<OpArg> groupByKeys;
+
+    // List<ArgAggFn>
+    private Optional<OpArg> groupByValues;
+
+    public GroupOp() {
+        super();
+        groupByKeys = Optional.empty();
+        groupByValues = Optional.empty();
+    }
+
+    public Optional<OpArg> getGroupByKeys() {
+        return groupByKeys;
+    }
+
+    public Optional<OpArg> getGroupByValues() {
+        return groupByValues;
+    }
+
+    public void setGroupByKeys(OpArg groupByKeys) {
+        this.groupByKeys = Optional.of(groupByKeys);
+    }
+
+    public void setGroupByValues(OpArg groupByValues) {
+        this.groupByValues = Optional.of(groupByValues);
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/IrCoreLibrary.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/IrCoreLibrary.java
@@ -99,6 +99,20 @@ public interface IrCoreLibrary extends Library {
 
     ResultCode appendAuxiliaOperator(Pointer plan, Pointer auxilia, int parent, IntByReference oprIdx);
 
+    Pointer initGroupbyOperator();
+
+    ResultCode addGroupbyKeyAlias(Pointer groupBy, FfiVariable.ByValue key, FfiAlias.ByValue alias);
+
+    ResultCode addGroupbyAggFn(Pointer groupBy, FfiAggFn.ByValue aggFn);
+
+    ResultCode appendGroupbyOperator(Pointer plan, Pointer groupBy, int parent, IntByReference oprIdx);
+
+    Pointer initDedupOperator();
+
+    ResultCode addDedupKey(Pointer dedup, FfiVariable.ByValue var);
+
+    ResultCode appendDedupOperator(Pointer plan, Pointer dedup, int parent, IntByReference oprIdx);
+
     FfiNameOrId.ByValue cstrAsNameOrId(String name);
 
     FfiConst.ByValue cstrAsConst(String value);
@@ -120,6 +134,8 @@ public interface IrCoreLibrary extends Library {
     FfiVariable.ByValue asVar(FfiNameOrId.ByValue tag, FfiProperty.ByValue property);
 
     FfiVariable.ByValue asNoneVar();
+
+    FfiAggFn.ByValue initAggFn(FfiAggOpt aggregate, FfiAlias.ByValue alias);
 
     void destroyJobBuffer(FfiJobBuffer value);
 }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAggFn.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAggFn.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.common.jna.type;
 
 import com.alibaba.graphscope.common.jna.IrTypeMapper;

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAggFn.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAggFn.java
@@ -1,0 +1,19 @@
+package com.alibaba.graphscope.common.jna.type;
+
+import com.alibaba.graphscope.common.jna.IrTypeMapper;
+import com.sun.jna.Pointer;
+import com.sun.jna.Structure;
+
+@Structure.FieldOrder({"vars", "aggregate", "alias"})
+public class FfiAggFn extends Structure {
+    public FfiAggFn() {
+        super(IrTypeMapper.INSTANCE);
+    }
+
+    public static class ByValue extends FfiAggFn implements Structure.ByValue {
+    }
+
+    public Pointer vars;
+    public FfiAggOpt aggregate;
+    public FfiAlias.ByValue alias;
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAggOpt.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAggOpt.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.common.jna.type;
 
 import com.alibaba.graphscope.common.jna.IntEnum;

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAggOpt.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAggOpt.java
@@ -1,0 +1,28 @@
+package com.alibaba.graphscope.common.jna.type;
+
+import com.alibaba.graphscope.common.jna.IntEnum;
+
+public enum FfiAggOpt implements IntEnum<FfiAggOpt> {
+    Sum,
+    Min,
+    Max,
+    Count,
+    CountDistinct,
+    ToList,
+    ToSet,
+    Avg;
+
+    @Override
+    public int getInt() {
+        return this.ordinal();
+    }
+
+    @Override
+    public FfiAggOpt getEnum(int i) {
+        FfiAggOpt opts[] = values();
+        if (i < opts.length && i >= 0) {
+            return opts[i];
+        }
+        return null;
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAlias.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiAlias.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.common.jna.type;
 
 import com.google.common.base.Objects;

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
@@ -221,4 +221,102 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
         }
         throw new UnsupportedEvalException(ctx.getClass(), "supported pattern is [as('..')]");
     }
+
+    @Override
+    public Traversal visitTraversalMethod_group(GremlinGSParser.TraversalMethod_groupContext ctx) {
+        Traversal traversal = graphTraversal.group();
+        if (ctx.traversalMethod_group_keyby() != null) {
+            traversal = visitTraversalMethod_group_keyby(ctx.traversalMethod_group_keyby());
+        }
+        if (ctx.traversalMethod_group_valueby() != null) {
+            traversal = visitTraversalMethod_group_valueby(ctx.traversalMethod_group_valueby());
+        }
+        return traversal;
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_groupCount(GremlinGSParser.TraversalMethod_groupCountContext ctx) {
+        Traversal traversal = graphTraversal.groupCount();
+        if (ctx.traversalMethod_group_keyby() != null) {
+            traversal = visitTraversalMethod_group_keyby(ctx.traversalMethod_group_keyby());
+        }
+        return traversal;
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_group_keyby(GremlinGSParser.TraversalMethod_group_keybyContext ctx) {
+        int childCount = ctx.getChildCount();
+        if (childCount == 4 && ctx.stringLiteral() != null) {
+            return graphTraversal.by(GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral()));
+        } else if (childCount == 4 && ctx.traversalMethod_values() != null) {
+            TraversalMethodVisitor nestedVisitor = new TraversalMethodVisitor(gvisitor,
+                    GremlinAntlrToJava.getTraversalSupplier().get());
+            Traversal nestedTraversal = nestedVisitor.visitTraversalMethod_values(ctx.traversalMethod_values());
+            return graphTraversal.by(nestedTraversal);
+        } else if (childCount == 6 && ctx.traversalMethod_values() != null && ctx.traversalMethod_as() != null) {
+            TraversalMethodVisitor nestedVisitor = new TraversalMethodVisitor(gvisitor,
+                    GremlinAntlrToJava.getTraversalSupplier().get());
+            nestedVisitor.visitTraversalMethod_values(ctx.traversalMethod_values());
+            Traversal nestedTraversal = nestedVisitor.visitTraversalMethod_as(ctx.traversalMethod_as());
+            return graphTraversal.by(nestedTraversal);
+        } else {
+            throw new UnsupportedEvalException(ctx.getClass(),
+                    "supported pattern is [group().by('..')] or [group().by(values('..'))] or [group().by(values('..')).as('..')]");
+        }
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_group_valueby(GremlinGSParser.TraversalMethod_group_valuebyContext ctx) {
+        int childCount = ctx.getChildCount();
+        if (childCount == 4 && ctx.traversalMethod_aggregate_func() != null) {
+            TraversalMethodVisitor nestedVisitor = new TraversalMethodVisitor(gvisitor,
+                    GremlinAntlrToJava.getTraversalSupplier().get());
+            Traversal nestedTraversal = nestedVisitor.visitTraversalMethod_aggregate_func(ctx.traversalMethod_aggregate_func());
+            return graphTraversal.by(nestedTraversal);
+        } else if (childCount == 6 && ctx.traversalMethod_aggregate_func() != null && ctx.traversalMethod_as() != null) {
+            TraversalMethodVisitor nestedVisitor = new TraversalMethodVisitor(gvisitor,
+                    GremlinAntlrToJava.getTraversalSupplier().get());
+            nestedVisitor.visitTraversalMethod_aggregate_func(ctx.traversalMethod_aggregate_func());
+            Traversal nestedTraversal = nestedVisitor.visitTraversalMethod_as(ctx.traversalMethod_as());
+            return graphTraversal.by(nestedTraversal);
+        } else {
+            throw new UnsupportedEvalException(ctx.getClass(),
+                    "supported pattern is [group().by(..).by(count())] or [group().by(..).by(fold())]" +
+                            " or [group().by(..).by(count().as('..'))] or [group().by(..).by(fold().as('..'))]");
+        }
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_aggregate_func(GremlinGSParser.TraversalMethod_aggregate_funcContext ctx) {
+        if (ctx.traversalMethod_count() != null) {
+            return visitTraversalMethod_count(ctx.traversalMethod_count());
+        } else if (ctx.traversalMethod_fold() != null) {
+            return visitTraversalMethod_fold(ctx.traversalMethod_fold());
+        } else {
+            throw new UnsupportedEvalException(ctx.getClass(), "supported pattern is [count()] or [fold()]");
+        }
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_count(GremlinGSParser.TraversalMethod_countContext ctx) {
+        return graphTraversal.count();
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_values(GremlinGSParser.TraversalMethod_valuesContext ctx) {
+        if (ctx.getChildCount() == 4 && ctx.stringLiteral() != null) {
+            return graphTraversal.values(GenericLiteralVisitor.getStringLiteral(ctx.stringLiteral()));
+        }
+        throw new UnsupportedEvalException(ctx.getClass(), "supported pattern is [values('..')]");
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_fold(GremlinGSParser.TraversalMethod_foldContext ctx) {
+        return graphTraversal.fold();
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_dedup(GremlinGSParser.TraversalMethod_dedupContext ctx) {
+        return graphTraversal.dedup();
+    }
 }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/TestUtils.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/TestUtils.java
@@ -34,7 +34,7 @@ public class TestUtils {
     public static String readJsonFromResource(String file) {
         try {
             URL url = TestUtils.class.getClassLoader().getResource(file);
-            return FileUtils.readFileToString(new File(url.toURI()));
+            return FileUtils.readFileToString(new File(url.toURI())).trim();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.common.intermediate.operator;
 
 import com.alibaba.graphscope.common.IrPlan;

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
@@ -1,0 +1,34 @@
+package com.alibaba.graphscope.common.intermediate.operator;
+
+import com.alibaba.graphscope.common.IrPlan;
+import com.alibaba.graphscope.common.TestUtils;
+import com.alibaba.graphscope.common.intermediate.ArgUtils;
+import com.alibaba.graphscope.common.jna.type.FfiVariable;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.function.Function;
+
+public class DedupOpTest {
+    private IrPlan irPlan = new IrPlan();
+
+    @Test
+    public void dedupTest() throws IOException {
+        DedupOp op = new DedupOp();
+        FfiVariable.ByValue dedupKey = ArgUtils.asNoneVar();
+        op.setDedupKeys(new OpArg(Collections.singletonList(dedupKey), Function.identity()));
+
+        irPlan.appendInterOp(op);
+        Assert.assertEquals(TestUtils.readJsonFromResource("dedup.json"), irPlan.getPlanAsJson());
+    }
+
+    @After
+    public void after() {
+        if (irPlan != null) {
+            irPlan.close();
+        }
+    }
+}

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.common.intermediate.operator;
 
 import com.alibaba.graphscope.common.IrPlan;

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
@@ -36,10 +36,11 @@ public class GroupOpTest {
     @Test
     public void groupTest() throws IOException {
         GroupOp op = new GroupOp();
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> groupKey = Pair.with(ArgUtils.asNoneVar(), ArgUtils.groupKeysAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> groupKey = Pair.with(ArgUtils.asNoneVar(),
+                ArgUtils.asFfiAlias("keys", false));
         op.setGroupByKeys(new OpArg(Collections.singletonList(groupKey), Function.identity()));
 
-        ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+        ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
         irPlan.appendInterOp(op);
@@ -50,10 +51,11 @@ public class GroupOpTest {
     public void groupByKeyTest() throws IOException {
         GroupOp op = new GroupOp();
         FfiProperty.ByValue keyP = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> groupKey = Pair.with((ArgUtils.asVarPropertyOnly(keyP)), ArgUtils.groupKeysAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> groupKey = Pair.with((ArgUtils.asVarPropertyOnly(keyP)),
+                ArgUtils.asFfiAlias("keys_name", false));
         op.setGroupByKeys(new OpArg(Collections.singletonList(groupKey), Function.identity()));
 
-        ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+        ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
         irPlan.appendInterOp(op);
@@ -64,10 +66,11 @@ public class GroupOpTest {
     public void groupByKeyByCountTest() throws IOException {
         GroupOp op = new GroupOp();
         FfiProperty.ByValue keyP = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> groupKey = Pair.with((ArgUtils.asVarPropertyOnly(keyP)), ArgUtils.groupKeysAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> groupKey = Pair.with((ArgUtils.asVarPropertyOnly(keyP)),
+                ArgUtils.asFfiAlias("keys_name", false));
         op.setGroupByKeys(new OpArg(Collections.singletonList(groupKey), Function.identity()));
 
-        ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+        ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
         irPlan.appendInterOp(op);

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
@@ -1,0 +1,68 @@
+package com.alibaba.graphscope.common.intermediate.operator;
+
+import com.alibaba.graphscope.common.IrPlan;
+import com.alibaba.graphscope.common.TestUtils;
+import com.alibaba.graphscope.common.intermediate.ArgAggFn;
+import com.alibaba.graphscope.common.intermediate.ArgUtils;
+import com.alibaba.graphscope.common.jna.type.*;
+import org.javatuples.Pair;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.function.Function;
+
+public class GroupOpTest {
+    private IrPlan irPlan = new IrPlan();
+
+    @Test
+    public void groupTest() throws IOException {
+        GroupOp op = new GroupOp();
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> groupKey = Pair.with(ArgUtils.asNoneVar(), ArgUtils.groupKeysAlias());
+        op.setGroupByKeys(new OpArg(Collections.singletonList(groupKey), Function.identity()));
+
+        ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+        op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
+
+        irPlan.appendInterOp(op);
+        Assert.assertEquals(TestUtils.readJsonFromResource("group.json"), irPlan.getPlanAsJson());
+    }
+
+    @Test
+    public void groupByKeyTest() throws IOException {
+        GroupOp op = new GroupOp();
+        FfiProperty.ByValue keyP = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> groupKey = Pair.with((ArgUtils.asVarPropertyOnly(keyP)), ArgUtils.groupKeysAlias());
+        op.setGroupByKeys(new OpArg(Collections.singletonList(groupKey), Function.identity()));
+
+        ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+        op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
+
+        irPlan.appendInterOp(op);
+        Assert.assertEquals(TestUtils.readJsonFromResource("group_key.json"), irPlan.getPlanAsJson());
+    }
+
+    @Test
+    public void groupByKeyByCountTest() throws IOException {
+        GroupOp op = new GroupOp();
+        FfiProperty.ByValue keyP = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> groupKey = Pair.with((ArgUtils.asVarPropertyOnly(keyP)), ArgUtils.groupKeysAlias());
+        op.setGroupByKeys(new OpArg(Collections.singletonList(groupKey), Function.identity()));
+
+        ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+        op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
+
+        irPlan.appendInterOp(op);
+        Assert.assertEquals(TestUtils.readJsonFromResource("group_key_count.json"), irPlan.getPlanAsJson());
+    }
+
+
+    @After
+    public void after() {
+        if (irPlan != null) {
+            irPlan.close();
+        }
+    }
+}

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/DedupStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/DedupStepTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.gremlin;
 
 import com.alibaba.graphscope.common.intermediate.ArgUtils;

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/DedupStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/DedupStepTest.java
@@ -1,0 +1,31 @@
+package com.alibaba.graphscope.gremlin;
+
+import com.alibaba.graphscope.common.intermediate.ArgUtils;
+import com.alibaba.graphscope.common.intermediate.operator.DedupOp;
+import com.alibaba.graphscope.common.jna.type.FfiVariable;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import com.alibaba.graphscope.gremlin.InterOpCollectionBuilder.StepTransformFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class DedupStepTest {
+    private Graph graph = TinkerFactory.createModern();
+    private GraphTraversalSource g = graph.traversal();
+
+    @Test
+    public void g_V_dedup_test() {
+        Traversal traversal = g.V().dedup();
+
+        Step step = traversal.asAdmin().getEndStep();
+        DedupOp op = (DedupOp) StepTransformFactory.DEDUP_STEP.apply(step);
+
+        FfiVariable.ByValue expectedVar = ArgUtils.asNoneVar();
+        Assert.assertEquals(Collections.singletonList(expectedVar), op.getDedupKeys().get().getArg());
+    }
+}

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GroupStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GroupStepTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 Alibaba Group Holding Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.alibaba.graphscope.gremlin;
 
 import com.alibaba.graphscope.common.intermediate.ArgAggFn;

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GroupStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GroupStepTest.java
@@ -43,8 +43,9 @@ public class GroupStepTest {
         Step step = traversal.asAdmin().getEndStep();
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
 
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asNoneVar(), ArgUtils.groupKeysAlias());
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asNoneVar(),
+                ArgUtils.asFfiAlias("keys", false));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
@@ -57,8 +58,9 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("keys_name", false));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
@@ -71,8 +73,9 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("keys_name", false));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
@@ -85,8 +88,9 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.asFfiAlias("a", true));
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("a", true));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
@@ -99,8 +103,9 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("keys_name", false));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
@@ -113,7 +118,8 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("keys_name", false));
         ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("b", true));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
@@ -127,8 +133,9 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("keys_name", false));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
@@ -141,7 +148,8 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("keys_name", false));
         ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("b", true));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
@@ -155,8 +163,9 @@ public class GroupStepTest {
         Step step = traversal.asAdmin().getEndStep();
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_COUNT_STEP.apply(step);
 
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asNoneVar(), ArgUtils.groupKeysAlias());
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asNoneVar(),
+                ArgUtils.asFfiAlias("keys", false));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
@@ -169,8 +178,9 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_COUNT_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("keys_name", false));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
@@ -183,8 +193,9 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_COUNT_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("keys_name", false));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
@@ -197,8 +208,9 @@ public class GroupStepTest {
         GroupOp op = (GroupOp) StepTransformFactory.GROUP_COUNT_STEP.apply(step);
 
         FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
-        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.asFfiAlias("a", true));
-        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty),
+                ArgUtils.asFfiAlias("a", true));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count,  ArgUtils.asFfiAlias("values", false));
 
         Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
         Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GroupStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GroupStepTest.java
@@ -1,0 +1,190 @@
+package com.alibaba.graphscope.gremlin;
+
+import com.alibaba.graphscope.common.intermediate.ArgAggFn;
+import com.alibaba.graphscope.common.intermediate.ArgUtils;
+import com.alibaba.graphscope.common.intermediate.operator.GroupOp;
+import com.alibaba.graphscope.common.jna.type.*;
+import org.apache.tinkerpop.gremlin.groovy.jsr223.dsl.credential.__;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import com.alibaba.graphscope.gremlin.InterOpCollectionBuilder.StepTransformFactory;
+import org.javatuples.Pair;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Collections;
+
+public class GroupStepTest {
+    private Graph graph = TinkerFactory.createModern();
+    private GraphTraversalSource g = graph.traversal();
+
+    @Test
+    public void g_V_group_test() {
+        Traversal traversal = g.V().group();
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
+
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asNoneVar(), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_group_by_key_test() {
+        Traversal traversal = g.V().group().by("name");
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_group_by_values_test() {
+        Traversal traversal = g.V().group().by(__.values("name"));
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_group_by_values_as_test() {
+        Traversal traversal = g.V().group().by(__.values("name").as("a"));
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.asFfiAlias("a", true));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_group_by_key_by_count_test() {
+        Traversal traversal = g.V().group().by("name").by(__.count());
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_group_by_key_by_count_as_test() {
+        Traversal traversal = g.V().group().by("name").by(__.count().as("b"));
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("b", true));
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_group_by_key_by_fold_test() {
+        Traversal traversal = g.V().group().by("name").by(__.fold());
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_group_by_key_by_fold_as_test() {
+        Traversal traversal = g.V().group().by("name").by(__.fold().as("b"));
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("b", true));
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+
+    @Test
+    public void g_V_groupCount_test() {
+        Traversal traversal = g.V().groupCount();
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_COUNT_STEP.apply(step);
+
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asNoneVar(), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_groupCount_by_key_test() {
+        Traversal traversal = g.V().groupCount().by("name");
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_COUNT_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_groupCount_by_values_test() {
+        Traversal traversal = g.V().groupCount().by(__.values("name"));
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_COUNT_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.groupKeysAlias());
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+
+    @Test
+    public void g_V_groupCount_by_values_as_test() {
+        Traversal traversal = g.V().groupCount().by(__.values("name").as("a"));
+        Step step = traversal.asAdmin().getEndStep();
+        GroupOp op = (GroupOp) StepTransformFactory.GROUP_COUNT_STEP.apply(step);
+
+        FfiProperty.ByValue keyProperty = ArgUtils.asFfiProperty("name");
+        Pair<FfiVariable.ByValue, FfiAlias.ByValue> expectedKey = Pair.with(ArgUtils.asVarPropertyOnly(keyProperty), ArgUtils.asFfiAlias("a", true));
+        ArgAggFn expectedValue = new ArgAggFn(FfiAggOpt.Count, ArgUtils.groupValuesAlias());
+
+        Assert.assertEquals(Collections.singletonList(expectedKey), op.getGroupByKeys().get().getArg());
+        Assert.assertEquals(Collections.singletonList(expectedValue), op.getGroupByValues().get().getArg());
+    }
+}

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/SelectStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/SelectStepTest.java
@@ -41,8 +41,8 @@ public class SelectStepTest {
         Step selectStep = traversal.asAdmin().getEndStep();
         ProjectOp op = (ProjectOp) StepTransformFactory.SELECT_BY_STEP.apply(selectStep);
         List<Pair> expected = Arrays.asList(
-                Pair.with("@a", ArgUtils.asFfiAlias("@a", false)),
-                Pair.with("@b", ArgUtils.asFfiAlias("@b", false)));
+                Pair.with("@a", ArgUtils.asFfiAlias("a", false)),
+                Pair.with("@b", ArgUtils.asFfiAlias("b", false)));
         Assert.assertEquals(expected, op.getProjectExprWithAlias().get().getArg());
     }
 
@@ -52,8 +52,8 @@ public class SelectStepTest {
         Step selectStep = traversal.asAdmin().getEndStep();
         ProjectOp op = (ProjectOp) StepTransformFactory.SELECT_BY_STEP.apply(selectStep);
         List<Pair> expected = Arrays.asList(
-                Pair.with("@a.name", ArgUtils.asFfiAlias("@a.name", false)),
-                Pair.with("@b.name", ArgUtils.asFfiAlias("@b.name", false)));
+                Pair.with("@a.name", ArgUtils.asFfiAlias("a_name", false)),
+                Pair.with("@b.name", ArgUtils.asFfiAlias("b_name", false)));
         Assert.assertEquals(expected, op.getProjectExprWithAlias().get().getArg());
     }
 }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/ValueMapTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/ValueMapTest.java
@@ -42,8 +42,8 @@ public class ValueMapTest {
         ProjectOp op = (ProjectOp) StepTransformFactory.VALUE_MAP_STEP.apply(valueMapStep);
 
         List<Pair> expected = Arrays.asList(
-                Pair.with("@.name", ArgUtils.asFfiAlias("@.name", false)),
-                Pair.with("@.id", ArgUtils.asFfiAlias("@.id", false)));
+                Pair.with("@.name", ArgUtils.asFfiAlias("name", false)),
+                Pair.with("@.id", ArgUtils.asFfiAlias("id", false)));
         Assert.assertEquals(expected, op.getProjectExprWithAlias().get().getArg());
     }
 }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
@@ -403,4 +403,73 @@ public class PositiveEvalTest {
         Assert.assertEquals(g.V().has("name", P.without("marko", "josh")).as("c"),
                 eval("g.V().has('name', without('marko', 'josh')).as('c')"));
     }
+
+    @Test
+    public void g_V_group_test() {
+        Assert.assertEquals(g.V().group(), eval("g.V().group()"));
+    }
+
+    @Test
+    public void g_V_group_by_key_str_test() {
+        Assert.assertEquals(g.V().group().by("name"), eval("g.V().group().by(\"name\")"));
+    }
+
+    @Test
+    public void g_V_group_by_key_values_test() {
+        Assert.assertEquals(g.V().group().by(__.values("name")), eval("g.V().group().by(values(\"name\"))"));
+    }
+
+    @Test
+    public void g_V_group_by_key_values_as_test() {
+        Assert.assertEquals(g.V().group().by(__.values("name").as("name")),
+                eval("g.V().group().by(values(\"name\").as(\"name\"))"));
+    }
+
+    @Test
+    public void g_V_group_by_key_str_by_value_count_test() {
+        Assert.assertEquals(g.V().group().by("name").by(__.count()), eval("g.V().group().by(\"name\").by(count())"));
+    }
+
+    @Test
+    public void g_V_group_by_key_values_by_value_fold_test() {
+        Assert.assertEquals(g.V().group().by(__.values("name")).by(__.fold()),
+                eval("g.V().group().by(values(\"name\")).by(fold())"));
+    }
+
+    @Test
+    public void g_V_group_by_key_str_by_value_count_as_test() {
+        Assert.assertEquals(g.V().group().by("name").by(__.count().as("a")),
+                eval("g.V().group().by(\"name\").by(count().as(\"a\"))"));
+    }
+
+    @Test
+    public void g_V_group_by_key_values_by_value_fold_as_test() {
+        Assert.assertEquals(g.V().group().by(__.values("name")).by(__.fold().as("a")),
+                eval("g.V().group().by(values(\"name\")).by(fold().as(\"a\"))"));
+    }
+
+    @Test
+    public void g_V_groupCount_test() {
+        Assert.assertEquals(g.V().groupCount(), eval("g.V().groupCount()"));
+    }
+
+    @Test
+    public void g_V_groupCount_by_str_test() {
+        Assert.assertEquals(g.V().groupCount().by("name"), eval("g.V().groupCount().by(\"name\")"));
+    }
+
+    @Test
+    public void g_V_groupCount_by_values_test() {
+        Assert.assertEquals(g.V().groupCount().by(__.values("name")), eval("g.V().groupCount().by(values(\"name\"))"));
+    }
+
+    @Test
+    public void g_V_groupCount_by_values_as_test() {
+        Assert.assertEquals(g.V().groupCount().by(__.values("name").as("a")), eval("g.V().groupCount().by(values(\"name\")).as(\"a\")"));
+    }
+
+    @Test
+    public void g_V_dedup_test() {
+        Assert.assertEquals(g.V().dedup(), eval("g.V().dedup()"));
+    }
 }

--- a/research/query_service/ir/compiler/src/test/resources/dedup.json
+++ b/research/query_service/ir/compiler/src/test/resources/dedup.json
@@ -1,0 +1,19 @@
+{
+  "nodes": [
+    {
+      "opr": {
+        "opr": {
+          "Dedup": {
+            "keys": [
+              {
+                "tag": null,
+                "property": null
+              }
+            ]
+          }
+        }
+      },
+      "children": []
+    }
+  ]
+}

--- a/research/query_service/ir/compiler/src/test/resources/group.json
+++ b/research/query_service/ir/compiler/src/test/resources/group.json
@@ -13,7 +13,7 @@
                 "alias": {
                   "alias": {
                     "item": {
-                      "Name": "~keys"
+                      "Name": "keys"
                     }
                   },
                   "is_query_given": false
@@ -27,7 +27,7 @@
                 "alias": {
                   "alias": {
                     "item": {
-                      "Name": "~values"
+                      "Name": "values"
                     }
                   },
                   "is_query_given": false

--- a/research/query_service/ir/compiler/src/test/resources/group.json
+++ b/research/query_service/ir/compiler/src/test/resources/group.json
@@ -1,0 +1,43 @@
+{
+  "nodes": [
+    {
+      "opr": {
+        "opr": {
+          "GroupBy": {
+            "mappings": [
+              {
+                "key": {
+                  "tag": null,
+                  "property": null
+                },
+                "alias": {
+                  "alias": {
+                    "item": {
+                      "Name": "~keys"
+                    }
+                  },
+                  "is_query_given": false
+                }
+              }
+            ],
+            "functions": [
+              {
+                "vars": [],
+                "aggregate": 5,
+                "alias": {
+                  "alias": {
+                    "item": {
+                      "Name": "~values"
+                    }
+                  },
+                  "is_query_given": false
+                }
+              }
+            ]
+          }
+        }
+      },
+      "children": []
+    }
+  ]
+}

--- a/research/query_service/ir/compiler/src/test/resources/group_key.json
+++ b/research/query_service/ir/compiler/src/test/resources/group_key.json
@@ -21,7 +21,7 @@
                 "alias": {
                   "alias": {
                     "item": {
-                      "Name": "~keys"
+                      "Name": "keys_name"
                     }
                   },
                   "is_query_given": false
@@ -35,7 +35,7 @@
                 "alias": {
                   "alias": {
                     "item": {
-                      "Name": "~values"
+                      "Name": "values"
                     }
                   },
                   "is_query_given": false

--- a/research/query_service/ir/compiler/src/test/resources/group_key.json
+++ b/research/query_service/ir/compiler/src/test/resources/group_key.json
@@ -1,0 +1,51 @@
+{
+  "nodes": [
+    {
+      "opr": {
+        "opr": {
+          "GroupBy": {
+            "mappings": [
+              {
+                "key": {
+                  "tag": null,
+                  "property": {
+                    "item": {
+                      "Key": {
+                        "item": {
+                          "Name": "name"
+                        }
+                      }
+                    }
+                  }
+                },
+                "alias": {
+                  "alias": {
+                    "item": {
+                      "Name": "~keys"
+                    }
+                  },
+                  "is_query_given": false
+                }
+              }
+            ],
+            "functions": [
+              {
+                "vars": [],
+                "aggregate": 5,
+                "alias": {
+                  "alias": {
+                    "item": {
+                      "Name": "~values"
+                    }
+                  },
+                  "is_query_given": false
+                }
+              }
+            ]
+          }
+        }
+      },
+      "children": []
+    }
+  ]
+}

--- a/research/query_service/ir/compiler/src/test/resources/group_key_count.json
+++ b/research/query_service/ir/compiler/src/test/resources/group_key_count.json
@@ -21,7 +21,7 @@
                 "alias": {
                   "alias": {
                     "item": {
-                      "Name": "~keys"
+                      "Name": "keys_name"
                     }
                   },
                   "is_query_given": false
@@ -35,7 +35,7 @@
                 "alias": {
                   "alias": {
                     "item": {
-                      "Name": "~values"
+                      "Name": "values"
                     }
                   },
                   "is_query_given": false

--- a/research/query_service/ir/compiler/src/test/resources/group_key_count.json
+++ b/research/query_service/ir/compiler/src/test/resources/group_key_count.json
@@ -1,0 +1,51 @@
+{
+  "nodes": [
+    {
+      "opr": {
+        "opr": {
+          "GroupBy": {
+            "mappings": [
+              {
+                "key": {
+                  "tag": null,
+                  "property": {
+                    "item": {
+                      "Key": {
+                        "item": {
+                          "Name": "name"
+                        }
+                      }
+                    }
+                  }
+                },
+                "alias": {
+                  "alias": {
+                    "item": {
+                      "Name": "~keys"
+                    }
+                  },
+                  "is_query_given": false
+                }
+              }
+            ],
+            "functions": [
+              {
+                "vars": [],
+                "aggregate": 3,
+                "alias": {
+                  "alias": {
+                    "item": {
+                      "Name": "~values"
+                    }
+                  },
+                  "is_query_given": false
+                }
+              }
+            ]
+          }
+        }
+      },
+      "children": []
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. add antlr parser of dedup && group
2. add transformations from gremlin step to intermediate operator for dedup and group
3. add jna api for setting and appending dedup && group
4. add test cases for dedup and group
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

