### PR TITLE
Enable get_head() when result of last op is aliased

### DIFF
--- a/research/query_service/ir/integrated/tests/auxilia_test.rs
+++ b/research/query_service/ir/integrated/tests/auxilia_test.rs
@@ -174,6 +174,72 @@ mod test {
         assert_eq!(result_ids_with_prop, expected_ids_with_prop)
     }
 
+    // g.V().out('knows').as("a").values('name')  // must obtain the name property
+    #[test]
+    fn auxilia_get_property_with_none_tag_input_test() {
+        let expand_opr = pb::EdgeExpand {
+            base: Some(pb::ExpandBase {
+                v_tag: None,
+                direction: 0,
+                params: Some(pb::QueryParams {
+                    table_names: vec![common_pb::NameOrId::from("knows".to_string())],
+                    columns: vec![],
+                    limit: None,
+                    predicate: None,
+                    requirements: vec![],
+                }),
+            }),
+            is_edge: false,
+            alias: Some("a".to_string().into()),
+        };
+
+        let auxilia_opr = pb::Auxilia {
+            tag: None,
+            params: Some(pb::QueryParams {
+                table_names: vec![],
+                columns: vec![common_pb::NameOrId::from("name".to_string())],
+                limit: None,
+                predicate: None,
+                requirements: vec![],
+            }),
+            alias: None,
+        };
+
+        let conf = JobConf::new("auxilia_get_property_with_none_tag_input_test");
+        let mut result = pegasus::run(conf, || {
+            let expand = expand_opr.clone();
+            let auxilia = auxilia_opr.clone();
+            |input, output| {
+                let mut stream = input.input_from(source_gen(None))?;
+                let flatmap_func = expand.gen_flat_map().unwrap();
+                stream = stream.flat_map(move |input| flatmap_func.exec(input))?;
+                let filter_map_func = auxilia.gen_filter_map().unwrap();
+                stream = stream.filter_map(move |input| filter_map_func.exec(input))?;
+                stream.sink_into(output)
+            }
+        })
+        .expect("build job failure");
+
+        let expected_ids_with_prop = vec![(2, "vadas".to_string().into()), (4, "josh".to_string().into())];
+        let mut result_ids_with_prop = vec![];
+        while let Some(Ok(record)) = result.next() {
+            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+                result_ids_with_prop.push((
+                    element.id(),
+                    element
+                        .details()
+                        .unwrap()
+                        .get_property(&NameOrId::Str("name".to_string()))
+                        .unwrap()
+                        .try_to_owned()
+                        .unwrap(),
+                ));
+            }
+        }
+        result_ids_with_prop.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        assert_eq!(result_ids_with_prop, expected_ids_with_prop)
+    }
+
     // g.V().out('knows').has('name', "vadas")
     #[test]
     fn auxilia_filter_test() {

--- a/research/query_service/ir/integrated/tests/auxilia_test.rs
+++ b/research/query_service/ir/integrated/tests/auxilia_test.rs
@@ -174,9 +174,9 @@ mod test {
         assert_eq!(result_ids_with_prop, expected_ids_with_prop)
     }
 
-    // g.V().out('knows').as("a").values('name')  // must obtain the name property
+    // g.V().out('knows').as("a").values('name')  // where we give alias "a" in out
     #[test]
-    fn auxilia_get_property_with_none_tag_input_test() {
+    fn auxilia_get_property_with_none_tag_input_test_01() {
         let expand_opr = pb::EdgeExpand {
             base: Some(pb::ExpandBase {
                 v_tag: None,
@@ -194,7 +194,7 @@ mod test {
         };
 
         let auxilia_opr = pb::Auxilia {
-            tag: None,
+            tag: Some("a".to_string().into()),
             params: Some(pb::QueryParams {
                 table_names: vec![],
                 columns: vec![common_pb::NameOrId::from("name".to_string())],
@@ -223,7 +223,81 @@ mod test {
         let expected_ids_with_prop = vec![(2, "vadas".to_string().into()), (4, "josh".to_string().into())];
         let mut result_ids_with_prop = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record
+                .get(Some(&NameOrId::Str("a".to_string())))
+                .unwrap()
+                .as_graph_element()
+            {
+                result_ids_with_prop.push((
+                    element.id(),
+                    element
+                        .details()
+                        .unwrap()
+                        .get_property(&NameOrId::Str("name".to_string()))
+                        .unwrap()
+                        .try_to_owned()
+                        .unwrap(),
+                ));
+            }
+        }
+        result_ids_with_prop.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
+        assert_eq!(result_ids_with_prop, expected_ids_with_prop)
+    }
+
+    // g.V().out('knows').as("a").values('name')   // where we give alias "a" in auxilia
+    #[test]
+    fn auxilia_get_property_with_none_tag_input_test_02() {
+        let expand_opr = pb::EdgeExpand {
+            base: Some(pb::ExpandBase {
+                v_tag: None,
+                direction: 0,
+                params: Some(pb::QueryParams {
+                    table_names: vec![common_pb::NameOrId::from("knows".to_string())],
+                    columns: vec![],
+                    limit: None,
+                    predicate: None,
+                    requirements: vec![],
+                }),
+            }),
+            is_edge: false,
+            alias: None,
+        };
+
+        let auxilia_opr = pb::Auxilia {
+            tag: None,
+            params: Some(pb::QueryParams {
+                table_names: vec![],
+                columns: vec![common_pb::NameOrId::from("name".to_string())],
+                limit: None,
+                predicate: None,
+                requirements: vec![],
+            }),
+            alias: Some("a".to_string().into()),
+        };
+
+        let conf = JobConf::new("auxilia_get_property_with_none_tag_input_test");
+        let mut result = pegasus::run(conf, || {
+            let expand = expand_opr.clone();
+            let auxilia = auxilia_opr.clone();
+            |input, output| {
+                let mut stream = input.input_from(source_gen(None))?;
+                let flatmap_func = expand.gen_flat_map().unwrap();
+                stream = stream.flat_map(move |input| flatmap_func.exec(input))?;
+                let filter_map_func = auxilia.gen_filter_map().unwrap();
+                stream = stream.filter_map(move |input| filter_map_func.exec(input))?;
+                stream.sink_into(output)
+            }
+        })
+        .expect("build job failure");
+
+        let expected_ids_with_prop = vec![(2, "vadas".to_string().into()), (4, "josh".to_string().into())];
+        let mut result_ids_with_prop = vec![];
+        while let Some(Ok(record)) = result.next() {
+            if let Some(element) = record
+                .get(Some(&NameOrId::Str("a".to_string())))
+                .unwrap()
+                .as_graph_element()
+            {
                 result_ids_with_prop.push((
                     element.id(),
                     element

--- a/research/query_service/ir/integrated/tests/expand_test.rs
+++ b/research/query_service/ir/integrated/tests/expand_test.rs
@@ -250,6 +250,33 @@ mod test {
         assert_eq!(result_ids, expected_ids)
     }
 
+    // g.V().as("a").out()
+    #[test]
+    fn expand_outv_from_none_tag_test() {
+        let query_param = pb::QueryParams {
+            table_names: vec!["knows".into()],
+            columns: vec![],
+            limit: None,
+            predicate: None,
+            requirements: vec![],
+        };
+        let edge_expand_base = pb::ExpandBase { v_tag: None, direction: 0, params: Some(query_param) };
+        let expand_opr_pb = pb::EdgeExpand { base: Some(edge_expand_base), is_edge: false, alias: None };
+        let mut result = expand_test_with_source_tag("a".into(), expand_opr_pb);
+        let mut result_ids = vec![];
+        let v2: DefaultId = LDBCVertexParser::to_global_id(2, 0);
+        let v4: DefaultId = LDBCVertexParser::to_global_id(4, 0);
+        let mut expected_ids = vec![v2, v4];
+        while let Some(Ok(record)) = result.next() {
+            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+                result_ids.push(element.id() as usize)
+            }
+        }
+        result_ids.sort();
+        expected_ids.sort();
+        assert_eq!(result_ids, expected_ids)
+    }
+
     // g.V().out('knows').has('id',2)
     #[test]
     fn expand_outv_filter_test() {

--- a/research/query_service/ir/runtime/src/process/operator/map/auxilia.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/auxilia.rs
@@ -43,6 +43,9 @@ impl FilterMapFunction<Record, Record> for AuxiliaOperator {
             .ok_or(FnExecError::get_tag_error("get tag failed in AuxiliaOperator"))?
             .clone();
         // Make sure there is anything to query with
+        // Note that we need to guarantee the requested column if it has any alias,
+        // e.g., for g.V().out().as("a").has("name", "marko"),
+        // when adding auxilia after out() step, we should set tag=Some("a") in auxilia
         if self.query_params.is_queryable() {
             // If queryable, then turn into graph element and do the query
             let vertex_or_edge = entry

--- a/research/query_service/ir/runtime/src/process/operator/map/auxilia.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/auxilia.rs
@@ -44,8 +44,12 @@ impl FilterMapFunction<Record, Record> for AuxiliaOperator {
             .clone();
         // Make sure there is anything to query with
         // Note that we need to guarantee the requested column if it has any alias,
-        // e.g., for g.V().out().as("a").has("name", "marko"),
-        // when adding auxilia after out() step, we should set tag=Some("a") in auxilia
+        // e.g., for g.V().out().as("a").has("name", "marko"), we could compile as:
+        // (1) g.V().out(as("a")).auxilia()... where we give alias in out,
+        //     then we set tag="a" and alias=None in auxilia
+        // (2) g.V().out().auxilia(as("a"))... where we give alias in auxilia,
+        //     then we set tag=None and alias="a" in auxilia
+        // TODO: it seems that we do not really care about getting head from curr or "a", we only need to save the updated entry with expected alias "a"
         if self.query_params.is_queryable() {
             // If queryable, then turn into graph element and do the query
             let vertex_or_edge = entry

--- a/research/query_service/ir/runtime/src/process/operator/map/project.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/project.rs
@@ -163,6 +163,30 @@ mod tests {
         assert_eq!(object_result, expected_result);
     }
 
+    // g.V().as("a").valueMap("id")
+    #[test]
+    fn project_none_tag_single_mapping_test() {
+        let project_opr_pb = pb::Project {
+            mappings: vec![pb::project::ExprAlias {
+                expr: Some(str_to_suffix_expr_pb("@.id".to_string()).unwrap()),
+                alias: Some(pb::Alias { alias: None, is_query_given: false }),
+            }],
+            is_append: false,
+        };
+        let mut result = project_test(init_source_with_tag(), project_opr_pb);
+        let mut object_result = vec![];
+        while let Some(Ok(res)) = result.next() {
+            match res.get(None).unwrap().as_ref() {
+                Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))) => {
+                    object_result.push(val.clone());
+                }
+                _ => {}
+            }
+        }
+        let expected_result = vec![object!(1), object!(2)];
+        assert_eq!(object_result, expected_result);
+    }
+
     // g.V().valueMap('age', 'name') with alias of 'age' as 'b' and 'name' as 'c'
     #[test]
     fn project_multi_mapping_test() {

--- a/research/query_service/ir/runtime/src/process/operator/mod.rs
+++ b/research/query_service/ir/runtime/src/process/operator/mod.rs
@@ -190,16 +190,13 @@ pub(crate) mod tests {
     }
 
     #[test]
+    // None tag refers to the last appended entry;
     fn test_get_none_tag_entry() {
         let tag_key = TagKey { tag: None, key: None };
-        let expected = init_vertex1();
         let record = init_record();
+        let expected = ObjectElement::Count(10).into();
         let entry = tag_key.get_entry(&record).unwrap();
-        if let Some(element) = entry.as_graph_element() {
-            assert_eq!(element.id(), expected.id());
-        } else {
-            assert!(false);
-        }
+        assert_eq!(entry.as_ref().clone(), expected)
     }
 
     #[test]

--- a/research/query_service/ir/runtime/src/process/record.rs
+++ b/research/query_service/ir/runtime/src/process/record.rs
@@ -72,13 +72,12 @@ pub struct Record {
 
 impl Record {
     pub fn new<E: Into<Entry>>(entry: E, tag: Option<NameOrId>) -> Self {
+        let entry = Arc::new(entry.into());
         let mut columns = IndexMap::new();
         if let Some(tag) = tag {
-            columns.insert(tag, Arc::new(entry.into()));
-            Record { curr: None, columns }
-        } else {
-            Record { curr: Some(Arc::new(entry.into())), columns }
+            columns.insert(tag.clone(), entry.clone());
         }
+        Record { curr: Some(entry), columns }
     }
 
     // TODO: consider to maintain the record without any alias, which also needed to be stored;
@@ -88,10 +87,9 @@ impl Record {
     }
 
     pub fn append_arc_entry(&mut self, entry: Arc<Entry>, alias: Option<NameOrId>) {
+        self.curr = Some(entry.clone());
         if let Some(alias) = alias {
-            self.columns.insert(alias, entry);
-        } else {
-            self.curr = Some(entry);
+            self.columns.insert(alias.clone(), entry);
         }
     }
 


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

