### PR TITLE
set worker=2 as default number of pegasus concurrency

### DIFF
--- a/research/query_service/ir/compiler/conf/ir.compiler.properties
+++ b/research/query_service/ir/compiler/conf/ir.compiler.properties
@@ -1,5 +1,5 @@
 # pegasus service config
-pegasus.worker.num: 1
+pegasus.worker.num: 2
 pegasus.timeout: 240000
 pegasus.batch.size: 1024
 pegasus.output.capacity: 16


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

