### PR TITLE
Support Lazy Details in Runtime and Storage Adapter

### DIFF
--- a/research/query_service/ir/graph_proxy/src/exp_store/graph_query.rs
+++ b/research/query_service/ir/graph_proxy/src/exp_store/graph_query.rs
@@ -433,7 +433,7 @@ impl Details for LazyVertexDetails {
         Some(&self.label)
     }
 
-    fn get_all_properties(&self) -> HashMap<NameOrId, Object> {
+    fn get_all_properties(&self) -> Option<HashMap<NameOrId, Object>> {
         let mut all_props = HashMap::new();
         if let Some(prop_keys) = self.prop_keys.as_ref() {
             // the case of get_all_properties from vertex;
@@ -453,7 +453,7 @@ impl Details for LazyVertexDetails {
                             ptr = swapped
                         };
                     } else {
-                        return all_props;
+                        return None;
                     }
                 }
                 unsafe {
@@ -462,6 +462,8 @@ impl Details for LazyVertexDetails {
                             .into_iter()
                             .map(|(prop_key, prop_val)| (prop_key.into(), prop_val as Object))
                             .collect();
+                    } else {
+                        return None;
                     }
                 }
             } else {
@@ -475,7 +477,7 @@ impl Details for LazyVertexDetails {
                 }
             }
         }
-        all_props
+        Some(all_props)
     }
 }
 

--- a/research/query_service/ir/graph_proxy/src/exp_store/graph_query.rs
+++ b/research/query_service/ir/graph_proxy/src/exp_store/graph_query.rs
@@ -433,9 +433,8 @@ impl Details for LazyVertexDetails {
         Some(&self.label)
     }
 
-    fn get_all_props_with_length(&self) -> (Box<dyn Iterator<Item = (NameOrId, Object)>>, usize) {
-        let mut all_props = vec![];
-        let mut all_props_len = 0;
+    fn get_all_properties(&self) -> HashMap<NameOrId, Object> {
+        let mut all_props = HashMap::new();
         if let Some(prop_keys) = self.prop_keys.as_ref() {
             // the case of get_all_properties from vertex;
             if prop_keys.is_empty() {
@@ -454,30 +453,29 @@ impl Details for LazyVertexDetails {
                             ptr = swapped
                         };
                     } else {
-                        return (Box::new(vec![].into_iter()), all_props_len);
+                        return all_props;
                     }
                 }
                 unsafe {
-                    if let Some(mut prop_key_vals) = (*ptr).clone_all_properties() {
-                        all_props_len = prop_key_vals.len();
-                        for (prop_key, prop_val) in prop_key_vals.drain() {
-                            all_props.push((prop_key.into(), prop_val as Object));
-                        }
+                    if let Some(prop_key_vals) = (*ptr).clone_all_properties() {
+                        all_props = prop_key_vals
+                            .into_iter()
+                            .map(|(prop_key, prop_val)| (prop_key.into(), prop_val as Object))
+                            .collect();
                     }
                 }
             } else {
                 // the case of get_all_properties with prop_keys pre-specified
-                all_props_len = prop_keys.len();
                 for key in prop_keys.iter() {
                     if let Some(prop) = self.get_property(&key) {
-                        all_props.push((key.clone(), prop.try_to_owned().unwrap()));
+                        all_props.insert(key.clone(), prop.try_to_owned().unwrap());
                     } else {
-                        all_props.push((key.clone(), Object::None))
+                        all_props.insert(key.clone(), Object::None);
                     }
                 }
             }
         }
-        (Box::new(all_props.into_iter()), all_props_len)
+        all_props
     }
 }
 

--- a/research/query_service/ir/runtime/src/graph/mod.rs
+++ b/research/query_service/ir/runtime/src/graph/mod.rs
@@ -125,7 +125,7 @@ impl QueryParams {
         mut self, required_properties_pb: Vec<common_pb::NameOrId>,
     ) -> Result<Self, ParsePbError> {
         // TODO: Specify whether we need all properties or None properties
-        // we assume that empty required_properties_pb vec indicates all properties needed
+        // TODO: for now, we assume that empty required_properties_pb vec indicates all properties needed
         self.props = Some(
             required_properties_pb
                 .into_iter()


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. Define `fn get_all_properties()` in `Trait Details` to enable get all properties from current GraphElement. Notice that it returns all props in the corresponding GraphElement(Vertex/Edge) in RUNTIME rather than STORE. 
2. Update the implementation in Storage Adapter. Specifically, we return `Vertex` with `LazyVertexDetails` rather than `DefaultDetails`. With `LazyVertexDetails`, the required properties will not be materialized until `LazyVertexDetails` need to be shuffled.
3. Encode/Decode for `DynDetails`. When decoding `DynDetails`, we decode it as `DefaultDetails`, i.e., we materialize the properties when it is shuffled. 



## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

