### PR TITLE
[Pegasus Service] add IterationEmit operator in Pegasus service

### DIFF
--- a/research/engine/pegasus/server-v0/proto/job_service.proto
+++ b/research/engine/pegasus/server-v0/proto/job_service.proto
@@ -111,6 +111,12 @@ message Iteration {
   TaskPlan body   = 3;
 }
 
+message IterationEmit {
+  uint32 max_iters = 1;
+  Filter until    = 2;
+  TaskPlan body   = 3;
+}
+
 message Apply {
   LeftJoin join = 1;
   TaskPlan task = 2;
@@ -170,6 +176,7 @@ message OperatorDef {
     Join join = 15;
     KeyBy key_by = 16;
     FilterMap filter_map = 17;
+    IterationEmit iterate_emit = 18;
   }
 }
 

--- a/research/query_service/ir/runtime/src/compiler.rs
+++ b/research/query_service/ir/runtime/src/compiler.rs
@@ -287,6 +287,9 @@ impl IRJobCompiler {
                             Err("iteration body can't be empty;")?
                         }
                     }
+                    server_pb::operator_def::OpKind::IterateEmit(_iter_emit) => {
+                        todo!()
+                    }
                     server_pb::operator_def::OpKind::Apply(sub) => {
                         let join_func = self.udf_gen.gen_subtask(
                             sub.join


### PR DESCRIPTION


<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Add `IterationEmit` operator  in service proto and related build apis.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

