### PR TITLE
Add GraphPath struct in Runtime

### DIFF
--- a/research/query_service/ir/integrated/tests/auxilia_test.rs
+++ b/research/query_service/ir/integrated/tests/auxilia_test.rs
@@ -96,7 +96,7 @@ mod test {
             if let Some(element) = record
                 .get(Some(&"a".to_string().into()))
                 .unwrap()
-                .as_graph_element()
+                .as_graph_vertex()
             {
                 result_ids.push(element.id());
             }
@@ -151,7 +151,7 @@ mod test {
         let expected_ids_with_prop = vec![(2, "vadas".to_string().into()), (4, "josh".to_string().into())];
         let mut result_ids_with_prop = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids_with_prop.push((
                     element.id(),
                     element
@@ -217,7 +217,7 @@ mod test {
             if let Some(element) = record
                 .get(Some(&NameOrId::Str("a".to_string())))
                 .unwrap()
-                .as_graph_element()
+                .as_graph_vertex()
             {
                 result_ids_with_prop.push((
                     element.id(),
@@ -281,7 +281,7 @@ mod test {
         let expected_ids_with_prop = vec![(2, "vadas".to_string().into())];
         let mut result_ids_with_prop = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids_with_prop.push((
                     element.id(),
                     element
@@ -347,7 +347,7 @@ mod test {
             if let Some(element) = record
                 .get(Some(&NameOrId::Str("a".to_string())))
                 .unwrap()
-                .as_graph_element()
+                .as_graph_vertex()
             {
                 result_ids.push(element.id());
             }

--- a/research/query_service/ir/integrated/tests/expand_test.rs
+++ b/research/query_service/ir/integrated/tests/expand_test.rs
@@ -30,7 +30,7 @@ mod test {
     use pegasus::api::{Map, Sink};
     use pegasus::result::ResultStream;
     use pegasus::JobConf;
-    use runtime::graph::element::{Element, GraphElement, VertexOrEdge};
+    use runtime::graph::element::{Element, GraphElement};
     use runtime::graph::property::Details;
     use runtime::process::operator::flatmap::FlatMapFuncGen;
     use runtime::process::operator::map::MapFuncGen;
@@ -95,7 +95,7 @@ mod test {
         let v5: DefaultId = LDBCVertexParser::to_global_id(5, 1);
         let mut expected_ids = vec![v2, v3, v3, v3, v4, v5];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize)
             }
         }
@@ -128,7 +128,7 @@ mod test {
         let v4: DefaultId = LDBCVertexParser::to_global_id(4, 0);
         let expected_edges = vec![(v1, v4), (v1, v2)];
         while let Some(Ok(record)) = result.next() {
-            if let Some(VertexOrEdge::E(e)) = record.get(None).unwrap().as_graph_element() {
+            if let Some(e) = record.get(None).unwrap().as_graph_edge() {
                 result_edges.push((e.src_id as usize, e.dst_id as usize));
             }
         }
@@ -163,7 +163,7 @@ mod test {
         let mut expected_edges = vec![(v1, v2), (v1, v3), (v1, v4), (v4, v3), (v4, v5), (v6, v3)];
         expected_edges.sort();
         while let Some(Ok(record)) = result.next() {
-            if let Some(VertexOrEdge::E(e)) = record.get(None).unwrap().as_graph_element() {
+            if let Some(e) = record.get(None).unwrap().as_graph_edge() {
                 result_edges.push((e.src_id as usize, e.dst_id as usize));
             }
         }
@@ -194,7 +194,7 @@ mod test {
         let expected_ids_with_prop =
             vec![(v1, "marko".to_string().into()), (v1, "marko".to_string().into())];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids_with_prop.push((
                     element.id() as usize,
                     element
@@ -263,7 +263,7 @@ mod test {
             if let Some(element) = record
                 .get(Some(&"b".into()))
                 .unwrap()
-                .as_graph_element()
+                .as_graph_vertex()
             {
                 result_ids.push(element.id() as usize)
             }
@@ -318,7 +318,7 @@ mod test {
         let v4: DefaultId = LDBCVertexParser::to_global_id(4, 0);
         let mut expected_ids = vec![v2, v4];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize)
             }
         }
@@ -349,7 +349,7 @@ mod test {
         let v2: DefaultId = LDBCVertexParser::to_global_id(2, 0);
         let expected_ids = vec![v2];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize)
             }
         }
@@ -397,7 +397,7 @@ mod test {
         let expected_ids = vec![2, 4];
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize);
                 assert!(element
                     .details()
@@ -451,7 +451,7 @@ mod test {
         let expected_ids = vec![1, 4, 4, 6];
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize);
                 assert!(element
                     .details()
@@ -505,7 +505,7 @@ mod test {
         let expected_ids = vec![1, 1, 2, 4];
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize);
                 assert!(element
                     .details()

--- a/research/query_service/ir/integrated/tests/graph_query_test.rs
+++ b/research/query_service/ir/integrated/tests/graph_query_test.rs
@@ -88,7 +88,7 @@ mod test {
             match result {
                 Ok(res) => {
                     let entry = parse_result(res).unwrap();
-                    if let Some(vertex) = entry.get(None).unwrap().as_graph_element() {
+                    if let Some(vertex) = entry.get(None).unwrap().as_graph_vertex() {
                         result_collection.push(vertex.id());
                     }
                 }

--- a/research/query_service/ir/integrated/tests/scan_test.rs
+++ b/research/query_service/ir/integrated/tests/scan_test.rs
@@ -54,7 +54,7 @@ mod test {
         let v6: DefaultId = LDBCVertexParser::to_global_id(6, 0);
         let mut expected_ids = vec![v1, v2, v3, v4, v5, v6];
         for record in source_iter {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize)
             }
         }
@@ -85,7 +85,7 @@ mod test {
         let v6: DefaultId = LDBCVertexParser::to_global_id(6, 0);
         let mut expected_ids = vec![v1, v2, v4, v6];
         for record in source_iter {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize)
             }
         }
@@ -118,7 +118,7 @@ mod test {
         let v6: DefaultId = LDBCVertexParser::to_global_id(6, 0);
         let mut expected_ids = vec![v1, v2, v3, v4, v5, v6];
         for record in source_iter {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize)
             }
         }
@@ -141,7 +141,7 @@ mod test {
         let v1: DefaultId = LDBCVertexParser::to_global_id(1, 0);
         let mut expected_ids = vec![v1];
         for record in source_iter {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize)
             }
         }
@@ -165,7 +165,7 @@ mod test {
         let v2: DefaultId = LDBCVertexParser::to_global_id(2, 0);
         let mut expected_ids = vec![v1, v2];
         for record in source_iter {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id() as usize)
             }
         }

--- a/research/query_service/ir/runtime/src/graph/element/edge.rs
+++ b/research/query_service/ir/runtime/src/graph/element/edge.rs
@@ -13,6 +13,8 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use std::io;
 
 use dyn_type::BorrowObject;
@@ -149,5 +151,25 @@ impl Decode for Edge {
 impl Context<Edge> for Edge {
     fn get(&self, _tag: Option<&NameOrId>) -> Option<&Edge> {
         Some(&self)
+    }
+}
+
+impl Hash for Edge {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state)
+    }
+}
+
+impl PartialEq for Edge {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl PartialOrd for Edge {
+    // TODO: not sure if it is reasonable. Edge may be not comparable.
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.as_borrow_object()
+            .partial_cmp(&other.as_borrow_object())
     }
 }

--- a/research/query_service/ir/runtime/src/graph/element/edge.rs
+++ b/research/query_service/ir/runtime/src/graph/element/edge.rs
@@ -14,16 +14,19 @@
 //! limitations under the License.
 
 use std::cmp::Ordering;
+use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
 use std::io;
 
 use dyn_type::BorrowObject;
+use ir_common::error::ParsePbError;
+use ir_common::generated::results as result_pb;
 use ir_common::NameOrId;
 use pegasus_common::codec::{Decode, Encode, ReadExt, WriteExt};
 
 use crate::expr::eval::Context;
 use crate::graph::element::{Element, GraphElement};
-use crate::graph::property::DynDetails;
+use crate::graph::property::{DefaultDetails, DynDetails};
 use crate::graph::{read_id, write_id, ID};
 
 #[derive(Clone, Debug)]
@@ -171,5 +174,31 @@ impl PartialOrd for Edge {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.as_borrow_object()
             .partial_cmp(&other.as_borrow_object())
+    }
+}
+
+impl TryFrom<result_pb::Edge> for Edge {
+    type Error = ParsePbError;
+    fn try_from(e: result_pb::Edge) -> Result<Self, Self::Error> {
+        let mut edge = Edge::new(
+            e.id as ID,
+            e.label
+                .map(|label| label.try_into())
+                .transpose()?,
+            e.src_id as ID,
+            e.dst_id as ID,
+            DynDetails::new(DefaultDetails::default()),
+        );
+        edge.set_src_label(
+            e.src_label
+                .map(|label| label.try_into())
+                .transpose()?,
+        );
+        edge.set_dst_label(
+            e.dst_label
+                .map(|label| label.try_into())
+                .transpose()?,
+        );
+        Ok(edge)
     }
 }

--- a/research/query_service/ir/runtime/src/graph/element/mod.rs
+++ b/research/query_service/ir/runtime/src/graph/element/mod.rs
@@ -220,6 +220,30 @@ pub enum GraphObject {
     P(GraphPath),
 }
 
+impl From<Vertex> for GraphObject {
+    fn from(v: Vertex) -> Self {
+        GraphObject::VOrE(v.into())
+    }
+}
+
+impl From<Edge> for GraphObject {
+    fn from(e: Edge) -> Self {
+        GraphObject::VOrE(e.into())
+    }
+}
+
+impl From<VertexOrEdge> for GraphObject {
+    fn from(v: VertexOrEdge) -> Self {
+        GraphObject::VOrE(v)
+    }
+}
+
+impl From<GraphPath> for GraphObject {
+    fn from(p: GraphPath) -> Self {
+        GraphObject::P(p)
+    }
+}
+
 impl Element for GraphObject {
     fn details(&self) -> Option<&DynDetails> {
         match self {

--- a/research/query_service/ir/runtime/src/graph/element/mod.rs
+++ b/research/query_service/ir/runtime/src/graph/element/mod.rs
@@ -26,6 +26,7 @@ use ir_common::NameOrId;
 use pegasus_common::codec::{Decode, Encode, ReadExt, WriteExt};
 pub use vertex::Vertex;
 
+use crate::graph::element::path::GraphPath;
 use crate::graph::property::{DefaultDetails, DynDetails};
 use crate::graph::ID;
 
@@ -62,6 +63,7 @@ impl<'a> Element for BorrowObject<'a> {
 }
 
 mod edge;
+mod path;
 mod vertex;
 
 #[derive(Clone, Debug)]

--- a/research/query_service/ir/runtime/src/graph/element/path.rs
+++ b/research/query_service/ir/runtime/src/graph/element/path.rs
@@ -15,11 +15,15 @@
 
 use std::cmp::Ordering;
 
+use dyn_type::BorrowObject;
+use ir_common::NameOrId;
 use pegasus::codec::{Decode, Encode, ReadExt, WriteExt};
 
-use crate::graph::element::VertexOrEdge;
+use crate::graph::element::{Element, GraphElement, VertexOrEdge};
+use crate::graph::property::DynDetails;
+use crate::graph::ID;
 
-#[derive(Clone, Debug, Hash)]
+#[derive(Clone, Debug, Hash, PartialEq, PartialOrd)]
 pub enum PathStruct {
     // save the whole path
     WHOLE(Vec<VertexOrEdge>),
@@ -35,9 +39,9 @@ pub struct GraphPath {
 }
 
 impl GraphPath {
-    // is_path_opt: Whether to save the whole path (true) or only the path_end (false)
-    pub fn new<E: Into<VertexOrEdge>>(entry: E, is_path_opt: bool) -> Self {
-        if is_path_opt {
+    // is_whole_path: Whether to preserve the whole path or only the path_end
+    pub fn new<E: Into<VertexOrEdge>>(entry: E, is_whole_path: bool) -> Self {
+        if is_whole_path {
             let mut path = Vec::new();
             path.push(entry.into());
             GraphPath { path: PathStruct::WHOLE(path), weight: 1 }
@@ -55,15 +59,44 @@ impl GraphPath {
     }
 }
 
-impl PartialEq for GraphPath {
-    fn eq(&self, _other: &Self) -> bool {
-        todo!()
+impl Element for GraphPath {
+    fn details(&self) -> Option<&DynDetails> {
+        None
+    }
+
+    fn as_graph_element(&self) -> Option<&dyn GraphElement> {
+        Some(self)
+    }
+
+    fn as_borrow_object(&self) -> BorrowObject {
+        BorrowObject::None
     }
 }
 
-impl PartialOrd for GraphPath {
-    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+impl GraphElement for GraphPath {
+    fn id(&self) -> ID {
         todo!()
+    }
+
+    fn label(&self) -> Option<&NameOrId> {
+        None
+    }
+
+    fn len(&self) -> usize {
+        self.weight
+    }
+}
+
+impl PartialEq for GraphPath {
+    fn eq(&self, other: &Self) -> bool {
+        // We define eq by structure, ignoring path weight
+        self.path.eq(&other.path)
+    }
+}
+impl PartialOrd for GraphPath {
+    // We define partial_cmp by structure, ignoring path weight
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.path.partial_cmp(&other.path)
     }
 }
 

--- a/research/query_service/ir/runtime/src/graph/element/path.rs
+++ b/research/query_service/ir/runtime/src/graph/element/path.rs
@@ -14,6 +14,8 @@
 //! limitations under the License.
 
 use std::cmp::Ordering;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 use dyn_type::BorrowObject;
 use ir_common::NameOrId;
@@ -140,7 +142,15 @@ impl Element for GraphPath {
 
 impl GraphElement for GraphPath {
     fn id(&self) -> ID {
-        todo!()
+        match self {
+            GraphPath::WHOLE((path, _)) => {
+                let ids: Vec<ID> = path.iter().map(|v| v.id()).collect();
+                let mut hasher = DefaultHasher::new();
+                ids.hash(&mut hasher);
+                hasher.finish() as ID
+            }
+            GraphPath::END((path_end, _)) => path_end.id(),
+        }
     }
 
     fn label(&self) -> Option<&NameOrId> {

--- a/research/query_service/ir/runtime/src/graph/element/path.rs
+++ b/research/query_service/ir/runtime/src/graph/element/path.rs
@@ -1,0 +1,116 @@
+//
+//! Copyright 2022 Alibaba Group Holding Limited.
+//!
+//! Licensed under the Apache License, Version 2.0 (the "License");
+//! you may not use this file except in compliance with the License.
+//! You may obtain a copy of the License at
+//!
+//! http://www.apache.org/licenses/LICENSE-2.0
+//!
+//! Unless required by applicable law or agreed to in writing, software
+//! distributed under the License is distributed on an "AS IS" BASIS,
+//! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//! See the License for the specific language governing permissions and
+//! limitations under the License.
+
+use crate::graph::element::VertexOrEdge;
+use pegasus::codec::{Encode, Decode, WriteExt, ReadExt};
+
+pub enum PathStruct {
+    // save the whole path
+    WHOLE(Vec<VertexOrEdge>),
+    // save the path_end
+    END(VertexOrEdge),
+}
+
+
+pub struct GraphPath {
+    path: PathStruct,
+    // TODO: may not be a usize, can be a WeightFunc that can define a user-given weight calculation
+    weight: usize,
+}
+
+impl GraphPath {
+    // is_path_opt: Whether to save the whole path (true) or only the path_end (false)
+    pub fn new<E: Into<VertexOrEdge>>(entry: E, is_path_opt: bool) -> Self {
+        if is_path_opt {
+            let mut path = Vec::new();
+            path.push(entry.into());
+            GraphPath { path: PathStruct::WHOLE(path), weight: 1 }
+        } else {
+            GraphPath { path: PathStruct::END(entry.into()), weight: 1 }
+        }
+    }
+
+    pub fn append<E: Into<VertexOrEdge>>(&mut self, entry: E) {
+        match self.path {
+            PathStruct::WHOLE(ref mut w) => {
+                w.push(entry.into())
+            }
+            PathStruct::END(ref mut e) => {
+                *e = entry.into()
+            }
+        }
+        self.weight += 1;
+    }
+}
+
+impl Encode for PathStruct {
+    fn write_to<W: WriteExt>(&self, writer: &mut W) -> std::io::Result<()> {
+       match self {
+           PathStruct::WHOLE(path) => {
+               writer.write_u8(0)?;
+               writer.write_u64(path.len() as u64)?;
+               for vertex_or_edge in path {
+                   vertex_or_edge.write_to(writer)?;
+               }
+           }
+           PathStruct::END(path_end) => {
+               writer.write_u8(1)?;
+               path_end.write_to(writer)?;
+           }
+       }
+        Ok(())
+    }
+}
+
+impl Decode for PathStruct {
+    fn read_from<R: ReadExt>(reader: &mut R) -> std::io::Result<Self> {
+        let opt = reader.read_u8()?;
+        match opt {
+            0 => {
+                let length =  <u64>::read_from(reader)?;
+                let mut path = Vec::with_capacity(length as usize);
+                for _i in 0..length {
+                    let vertex_or_edge = <VertexOrEdge>::read_from(reader)?;
+                    path.push(vertex_or_edge)
+                }
+                Ok(PathStruct::WHOLE(path))
+            }
+            1 => {
+                let vertex_or_edge = <VertexOrEdge>::read_from(reader)?;
+                Ok(PathStruct::END(vertex_or_edge))
+            }
+            _ => Err(std::io::Error::new(std::io::ErrorKind::Other, "unreachable")),
+        }
+    }
+}
+
+impl Encode for GraphPath {
+    fn write_to<W: WriteExt>(&self, writer: &mut W) -> std::io::Result<()> {
+        self.path.write_to(writer)?;
+        writer.write_u64(self.weight as u64)?;
+        Ok(())
+    }
+}
+
+impl Decode for GraphPath {
+    fn read_from<R: ReadExt>(reader: &mut R) -> std::io::Result<Self> {
+        let path = <PathStruct>::read_from(reader)?;
+        let weight = <u64>::read_from(reader)? as usize;
+        Ok(GraphPath {
+            path,
+            weight
+        })
+    }
+}

--- a/research/query_service/ir/runtime/src/graph/element/vertex.rs
+++ b/research/query_service/ir/runtime/src/graph/element/vertex.rs
@@ -14,16 +14,19 @@
 //! limitations under the License.
 
 use std::cmp::Ordering;
+use std::convert::{TryFrom, TryInto};
 use std::hash::{Hash, Hasher};
 use std::io;
 
 use dyn_type::BorrowObject;
+use ir_common::error::ParsePbError;
+use ir_common::generated::results as result_pb;
 use ir_common::NameOrId;
 use pegasus_common::codec::{Decode, Encode, ReadExt, WriteExt};
 
 use crate::expr::eval::Context;
 use crate::graph::element::{Element, GraphElement};
-use crate::graph::property::DynDetails;
+use crate::graph::property::{DefaultDetails, DynDetails};
 use crate::graph::{read_id, write_id, ID};
 
 #[derive(Clone, Debug)]
@@ -108,5 +111,19 @@ impl PartialOrd for Vertex {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         self.as_borrow_object()
             .partial_cmp(&other.as_borrow_object())
+    }
+}
+
+impl TryFrom<result_pb::Vertex> for Vertex {
+    type Error = ParsePbError;
+    fn try_from(v: result_pb::Vertex) -> Result<Self, Self::Error> {
+        let vertex = Vertex::new(
+            v.id as ID,
+            v.label
+                .map(|label| label.try_into())
+                .transpose()?,
+            DynDetails::new(DefaultDetails::default()),
+        );
+        Ok(vertex)
     }
 }

--- a/research/query_service/ir/runtime/src/graph/element/vertex.rs
+++ b/research/query_service/ir/runtime/src/graph/element/vertex.rs
@@ -13,6 +13,8 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
 use std::io;
 
 use dyn_type::BorrowObject;
@@ -86,5 +88,25 @@ impl Decode for Vertex {
 impl Context<Vertex> for Vertex {
     fn get(&self, _tag: Option<&NameOrId>) -> Option<&Vertex> {
         Some(&self)
+    }
+}
+
+impl Hash for Vertex {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.id.hash(state)
+    }
+}
+
+impl PartialEq for Vertex {
+    fn eq(&self, other: &Self) -> bool {
+        self.id() == other.id()
+    }
+}
+
+impl PartialOrd for Vertex {
+    // TODO: not sure if it is reasonable. Vertex may be not comparable.
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.as_borrow_object()
+            .partial_cmp(&other.as_borrow_object())
     }
 }

--- a/research/query_service/ir/runtime/src/process/operator/accum/accum.rs
+++ b/research/query_service/ir/runtime/src/process/operator/accum/accum.rs
@@ -26,7 +26,7 @@ use crate::error::{FnExecError, FnExecResult, FnGenError, FnGenResult};
 use crate::process::operator::accum::accumulator::{Accumulator, Count, ToList};
 use crate::process::operator::accum::AccumFactoryGen;
 use crate::process::operator::TagKey;
-use crate::process::record::{Entry, ObjectElement, Record};
+use crate::process::record::{CommonObject, Entry, Record};
 
 #[derive(Debug, Clone)]
 pub enum EntryAccumulator {
@@ -71,7 +71,7 @@ impl Accumulator<Arc<Entry>, Arc<Entry>> for EntryAccumulator {
         match self {
             EntryAccumulator::ToCount(count) => {
                 let cnt = count.finalize()?;
-                Ok(Arc::new(ObjectElement::Count(cnt).into()))
+                Ok(Arc::new(CommonObject::Count(cnt).into()))
             }
             EntryAccumulator::ToList(list) => {
                 let list_entry = list
@@ -154,7 +154,7 @@ mod tests {
     use crate::process::operator::accum::accumulator::Accumulator;
     use crate::process::operator::accum::AccumFactoryGen;
     use crate::process::operator::tests::{init_source, init_vertex1, init_vertex2};
-    use crate::process::record::{Entry, ObjectElement, Record, RecordElement};
+    use crate::process::record::{CommonObject, Entry, Record, RecordElement};
 
     fn fold_test(source: Vec<Record>, fold_opr_pb: pb::GroupBy) -> ResultStream<Record> {
         let conf = JobConf::new("fold_test");
@@ -218,7 +218,7 @@ mod tests {
         if let Some(Ok(record)) = result.next() {
             if let Some(entry) = record.get(Some(&"a".into())) {
                 cnt = match entry.as_ref() {
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Count(cnt))) => *cnt,
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Count(cnt))) => *cnt,
                     _ => {
                         unreachable!()
                     }
@@ -243,13 +243,13 @@ mod tests {
         };
         let fold_opr_pb = pb::GroupBy { mappings: vec![], functions: vec![function_1, function_2] };
         let mut result = fold_test(init_source(), fold_opr_pb);
-        let mut fold_result: (Entry, Entry) = (Entry::Collection(vec![]), ObjectElement::Count(0).into());
+        let mut fold_result: (Entry, Entry) = (Entry::Collection(vec![]), CommonObject::Count(0).into());
         let expected_result: (Entry, Entry) = (
             Entry::Collection(vec![
                 RecordElement::OnGraph(init_vertex1().into()),
                 RecordElement::OnGraph(init_vertex2().into()),
             ]),
-            ObjectElement::Count(2).into(),
+            CommonObject::Count(2).into(),
         );
         if let Some(Ok(record)) = result.next() {
             let collection_entry = record

--- a/research/query_service/ir/runtime/src/process/operator/filter/select.rs
+++ b/research/query_service/ir/runtime/src/process/operator/filter/select.rs
@@ -115,7 +115,7 @@ mod tests {
         let mut result = select_test(init_source(), select_opr_pb);
         let mut count = 0;
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 assert!(element.id() < 2)
             }
             count += 1;
@@ -131,7 +131,7 @@ mod tests {
         let mut result = select_test(init_source(), select_opr_pb);
         let mut count = 0;
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 assert!(element.id() > 1)
             }
             count += 1;
@@ -147,7 +147,7 @@ mod tests {
         let mut result = select_test(init_source(), select_opr_pb);
         let mut count = 0;
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 assert!(element.id() < 2)
             }
             count += 1;
@@ -164,7 +164,7 @@ mod tests {
         let mut result = select_test(init_source(), select_opr_pb);
         let mut count = 0;
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 {
                     assert_eq!(
                         element
@@ -191,7 +191,7 @@ mod tests {
         let mut result = select_test(init_source(), select_opr_pb);
         let mut count = 0;
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 {
                     assert_eq!(element.id(), 1);
                 }
@@ -209,7 +209,7 @@ mod tests {
         let mut result = select_test(init_source(), select_opr_pb);
         let mut count = 0;
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 {
                     assert_eq!(element.label().unwrap().clone(), "person".into());
                 }

--- a/research/query_service/ir/runtime/src/process/operator/group/fold.rs
+++ b/research/query_service/ir/runtime/src/process/operator/group/fold.rs
@@ -23,7 +23,7 @@ use pegasus_server::pb as server_pb;
 use crate::error::{FnGenError, FnGenResult};
 use crate::process::functions::FoldGen;
 use crate::process::operator::accum::{AccumFactoryGen, RecordAccumulator};
-use crate::process::record::{Entry, ObjectElement, Record};
+use crate::process::record::{CommonObject, Entry, Record};
 
 impl FoldGen<u64, Record> for algebra_pb::GroupBy {
     fn get_accum_kind(&self) -> server_pb::AccumKind {
@@ -65,7 +65,7 @@ struct CountAlias {
 
 impl MapFunction<u64, Record> for CountAlias {
     fn exec(&self, cnt: u64) -> FnResult<Record> {
-        let cnt_entry: Entry = ObjectElement::Count(cnt).into();
+        let cnt_entry: Entry = CommonObject::Count(cnt).into();
         Ok(Record::new(cnt_entry, self.alias.clone()))
     }
 }
@@ -81,7 +81,7 @@ mod tests {
 
     use crate::process::functions::FoldGen;
     use crate::process::operator::tests::init_source;
-    use crate::process::record::{Entry, ObjectElement, Record, RecordElement};
+    use crate::process::record::{CommonObject, Entry, Record, RecordElement};
 
     fn count_test(source: Vec<Record>, fold_opr_pb: pb::GroupBy) -> ResultStream<Record> {
         let conf = JobConf::new("fold_test");
@@ -119,7 +119,7 @@ mod tests {
         if let Some(Ok(record)) = result.next() {
             if let Some(entry) = record.get(None) {
                 cnt = match entry.as_ref() {
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Count(cnt))) => *cnt,
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Count(cnt))) => *cnt,
                     _ => {
                         unreachable!()
                     }
@@ -143,7 +143,7 @@ mod tests {
         if let Some(Ok(record)) = result.next() {
             if let Some(entry) = record.get(Some(&"a".into())) {
                 cnt = match entry.as_ref() {
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Count(cnt))) => *cnt,
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Count(cnt))) => *cnt,
                     _ => {
                         unreachable!()
                     }

--- a/research/query_service/ir/runtime/src/process/operator/group/group.rs
+++ b/research/query_service/ir/runtime/src/process/operator/group/group.rs
@@ -95,7 +95,7 @@ mod tests {
     use crate::process::functions::GroupGen;
     use crate::process::operator::accum::accumulator::Accumulator;
     use crate::process::operator::tests::{init_source, init_vertex1, init_vertex2};
-    use crate::process::record::{Entry, ObjectElement, Record, RecordElement};
+    use crate::process::record::{CommonObject, Entry, Record, RecordElement};
 
     // v1: marko, 29;
     // v2: vadas, 27;
@@ -194,14 +194,14 @@ mod tests {
         let mut group_result = HashSet::new();
         let expected_result: HashSet<(Entry, Entry)> = [
             (
-                ObjectElement::Prop(object!("marko")).into(),
+                CommonObject::Prop(object!("marko")).into(),
                 Entry::Collection(vec![
                     RecordElement::OnGraph(init_vertex1().into()),
                     RecordElement::OnGraph(init_vertex3().into()),
                 ]),
             ),
             (
-                ObjectElement::Prop(object!("vadas")).into(),
+                CommonObject::Prop(object!("vadas")).into(),
                 Entry::Collection(vec![RecordElement::OnGraph(init_vertex2().into())]),
             ),
         ]
@@ -239,15 +239,15 @@ mod tests {
         let mut group_result = HashSet::new();
         let expected_result: HashSet<((Entry, Entry), Entry)> = [
             (
-                (ObjectElement::Prop(object!(1)).into(), ObjectElement::Prop(object!("marko")).into()),
+                (CommonObject::Prop(object!(1)).into(), CommonObject::Prop(object!("marko")).into()),
                 Entry::Collection(vec![RecordElement::OnGraph(init_vertex1().into())]),
             ),
             (
-                (ObjectElement::Prop(object!(2)).into(), ObjectElement::Prop(object!("vadas")).into()),
+                (CommonObject::Prop(object!(2)).into(), CommonObject::Prop(object!("vadas")).into()),
                 Entry::Collection(vec![RecordElement::OnGraph(init_vertex2().into())]),
             ),
             (
-                (ObjectElement::Prop(object!(3)).into(), ObjectElement::Prop(object!("marko")).into()),
+                (CommonObject::Prop(object!(3)).into(), CommonObject::Prop(object!("marko")).into()),
                 Entry::Collection(vec![RecordElement::OnGraph(init_vertex3().into())]),
             ),
         ]
@@ -290,21 +290,21 @@ mod tests {
                 init_vertex1().into(),
                 (
                     Entry::Collection(vec![RecordElement::OnGraph(init_vertex1().into())]),
-                    ObjectElement::Count(1).into(),
+                    CommonObject::Count(1).into(),
                 ),
             ),
             (
                 init_vertex2().into(),
                 (
                     Entry::Collection(vec![RecordElement::OnGraph(init_vertex2().into())]),
-                    ObjectElement::Count(1).into(),
+                    CommonObject::Count(1).into(),
                 ),
             ),
             (
                 init_vertex3().into(),
                 (
                     Entry::Collection(vec![RecordElement::OnGraph(init_vertex3().into())]),
-                    ObjectElement::Count(1).into(),
+                    CommonObject::Count(1).into(),
                 ),
             ),
         ]
@@ -337,9 +337,9 @@ mod tests {
         let mut result = group_test(group_opr_pb);
         let mut group_result = HashSet::new();
         let expected_result: HashSet<(Entry, Entry)> = [
-            (init_vertex1().into(), ObjectElement::Count(1).into()),
-            (init_vertex2().into(), ObjectElement::Count(1).into()),
-            (init_vertex3().into(), ObjectElement::Count(1).into()),
+            (init_vertex1().into(), CommonObject::Count(1).into()),
+            (init_vertex2().into(), CommonObject::Count(1).into()),
+            (init_vertex3().into(), CommonObject::Count(1).into()),
         ]
         .iter()
         .cloned()
@@ -368,8 +368,8 @@ mod tests {
         let mut result = group_test(group_opr_pb);
         let mut group_result = HashSet::new();
         let expected_result: HashSet<(Entry, Entry)> = [
-            (ObjectElement::Prop("marko".into()).into(), ObjectElement::Count(2).into()),
-            (ObjectElement::Prop("vadas".into()).into(), ObjectElement::Count(1).into()),
+            (CommonObject::Prop("marko".into()).into(), CommonObject::Count(2).into()),
+            (CommonObject::Prop("vadas".into()).into(), CommonObject::Count(1).into()),
         ]
         .iter()
         .cloned()

--- a/research/query_service/ir/runtime/src/process/operator/join/join.rs
+++ b/research/query_service/ir/runtime/src/process/operator/join/join.rs
@@ -159,7 +159,7 @@ mod tests {
 
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id());
             }
         }

--- a/research/query_service/ir/runtime/src/process/operator/keyed/keyed.rs
+++ b/research/query_service/ir/runtime/src/process/operator/keyed/keyed.rs
@@ -126,7 +126,7 @@ mod tests {
 
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id());
             }
         }

--- a/research/query_service/ir/runtime/src/process/operator/map/project.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/project.rs
@@ -27,7 +27,7 @@ use crate::error::{FnExecError, FnGenResult};
 use crate::expr::eval::{Evaluate, Evaluator};
 use crate::process::operator::map::MapFuncGen;
 use crate::process::operator::TagKey;
-use crate::process::record::{Entry, ObjectElement, Record, RecordElement};
+use crate::process::record::{CommonObject, Entry, Record, RecordElement};
 
 #[derive(Debug)]
 struct ProjectOperator {
@@ -49,8 +49,8 @@ fn exec_projector(input: &Record, projector: &Projector) -> FnResult<Arc<Entry>>
                 .map_err(|e| FnExecError::from(e))?;
             Arc::new(
                 match projected_result {
-                    Object::None => ObjectElement::None,
-                    _ => ObjectElement::Prop(projected_result),
+                    Object::None => CommonObject::None,
+                    _ => CommonObject::Prop(projected_result),
                 }
                 .into(),
             )
@@ -139,7 +139,7 @@ mod tests {
     use crate::process::operator::tests::{
         init_source, init_source_with_multi_tags, init_source_with_tag, init_vertex1, init_vertex2,
     };
-    use crate::process::record::{Entry, ObjectElement, Record, RecordElement};
+    use crate::process::record::{CommonObject, Entry, Record, RecordElement};
 
     fn project_test(source: Vec<Record>, project_opr_pb: pb::Project) -> ResultStream<Record> {
         let conf = JobConf::new("project_test");
@@ -172,7 +172,7 @@ mod tests {
         let mut object_result = vec![];
         while let Some(Ok(res)) = result.next() {
             match res.get(None).unwrap().as_ref() {
-                Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))) => {
+                Entry::Element(RecordElement::OffGraph(CommonObject::Prop(val))) => {
                     object_result.push(val.clone());
                 }
                 _ => {}
@@ -199,7 +199,7 @@ mod tests {
             let a_entry = res.get(Some(&"a".into()));
             assert_eq!(a_entry, None);
             match res.get(Some(&"b".into())).unwrap().as_ref() {
-                Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))) => {
+                Entry::Element(RecordElement::OffGraph(CommonObject::Prop(val))) => {
                     object_result.push(val.clone());
                 }
                 _ => {}
@@ -223,7 +223,7 @@ mod tests {
         let mut object_result = vec![];
         while let Some(Ok(res)) = result.next() {
             match res.get(None).unwrap().as_ref() {
-                Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))) => {
+                Entry::Element(RecordElement::OffGraph(CommonObject::Prop(val))) => {
                     object_result.push(val.clone());
                 }
                 _ => {}
@@ -256,8 +256,8 @@ mod tests {
             let name_val = res.get(Some(&"c".into())).unwrap();
             match (age_val.as_ref(), name_val.as_ref()) {
                 (
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(age))),
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(name))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(age))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(name))),
                 ) => {
                     object_result.push((age.clone(), name.clone()));
                 }
@@ -291,8 +291,8 @@ mod tests {
             let name_val = res.get(None).unwrap();
             match (age_val.as_ref(), name_val.as_ref()) {
                 (
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(age))),
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(name))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(age))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(name))),
                 ) => {
                     object_result.push((age.clone(), name.clone()));
                 }
@@ -327,8 +327,8 @@ mod tests {
             let name_val = res.get(Some(&"c".into())).unwrap();
             match (age_val.as_ref(), name_val.as_ref()) {
                 (
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(age))),
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(name))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(age))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(name))),
                 ) => {
                     object_result.push((age.clone(), name.clone()));
                 }
@@ -384,9 +384,9 @@ mod tests {
             let b_name_val = res.get(Some(&"e".into())).unwrap();
             match (a_age_val.as_ref(), a_name_val.as_ref(), b_name_val.as_ref()) {
                 (
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(a_age))),
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(a_name))),
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(b_name))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(a_age))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(a_name))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(b_name))),
                 ) => {
                     object_result.push((a_age.clone(), a_name.clone(), b_name.clone()));
                 }
@@ -421,7 +421,7 @@ mod tests {
                 .unwrap();
             let b_entry = res.get(Some(&"b".into())).unwrap().as_ref();
             match b_entry {
-                Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))) => {
+                Entry::Element(RecordElement::OffGraph(CommonObject::Prop(val))) => {
                     a_results.push(v.id());
                     b_results.push(val.clone());
                 }
@@ -457,8 +457,8 @@ mod tests {
             let name_val = res.get(Some(&"c".into())).unwrap();
             match (age_val.as_ref(), name_val.as_ref()) {
                 (
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(age))),
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(name))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(age))),
+                    Entry::Element(RecordElement::OffGraph(CommonObject::Prop(name))),
                 ) => {
                     object_result.push((age.clone(), name.clone()));
                 }
@@ -512,7 +512,7 @@ mod tests {
         let mut object_result = vec![];
         while let Some(Ok(res)) = result.next() {
             match res.get(None).unwrap().as_ref() {
-                Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))) => {
+                Entry::Element(RecordElement::OffGraph(CommonObject::Prop(val))) => {
                     object_result.push(val.clone());
                 }
                 _ => {}
@@ -539,7 +539,7 @@ mod tests {
         let mut object_result = vec![];
         while let Some(Ok(res)) = result.next() {
             match res.get(None).unwrap().as_ref() {
-                Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))) => {
+                Entry::Element(RecordElement::OffGraph(CommonObject::Prop(val))) => {
                     object_result.push(val.clone());
                 }
                 _ => {}
@@ -580,7 +580,7 @@ mod tests {
         let mut object_result = vec![];
         while let Some(Ok(res)) = result.next() {
             match res.get(None).unwrap().as_ref() {
-                Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))) => {
+                Entry::Element(RecordElement::OffGraph(CommonObject::Prop(val))) => {
                     object_result.push(val.clone());
                 }
                 _ => {}

--- a/research/query_service/ir/runtime/src/process/operator/map/project.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/project.rs
@@ -133,7 +133,7 @@ mod tests {
     use pegasus::result::ResultStream;
     use pegasus::JobConf;
 
-    use crate::graph::element::{GraphElement, Vertex};
+    use crate::graph::element::{GraphElement, GraphObject, Vertex};
     use crate::graph::property::{DefaultDetails, DynDetails};
     use crate::process::operator::map::MapFuncGen;
     use crate::process::operator::tests::{
@@ -418,7 +418,7 @@ mod tests {
             let b_entry = res.get(Some(&"b".into())).unwrap().as_ref();
             match (a_entry, b_entry) {
                 (
-                    Entry::Element(RecordElement::OnGraph(v)),
+                    Entry::Element(RecordElement::OnGraph(GraphObject::VOrE(v))),
                     Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))),
                 ) => {
                     a_results.push(v.id());
@@ -627,16 +627,10 @@ mod tests {
         while let Some(Ok(res)) = result.next() {
             let a_entry = res.get(Some(&"a_col".into())).unwrap().as_ref();
             let b_entry = res.get(Some(&"b_col".into())).unwrap().as_ref();
-            match (a_entry, b_entry) {
-                (
-                    Entry::Element(RecordElement::OnGraph(v1)),
-                    Entry::Element(RecordElement::OnGraph(v2)),
-                ) => {
-                    results.push(v1.id());
-                    results.push(v2.id());
-                }
-                _ => {}
-            }
+            let v1 = a_entry.as_graph_element().unwrap();
+            let v2 = b_entry.as_graph_element().unwrap();
+            results.push(v1.id());
+            results.push(v2.id());
         }
         let expected_results = vec![1, 2];
         assert_eq!(results, expected_results);

--- a/research/query_service/ir/runtime/src/process/operator/map/project.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/project.rs
@@ -133,7 +133,7 @@ mod tests {
     use pegasus::result::ResultStream;
     use pegasus::JobConf;
 
-    use crate::graph::element::{GraphElement, GraphObject, Vertex};
+    use crate::graph::element::{GraphElement, Vertex};
     use crate::graph::property::{DefaultDetails, DynDetails};
     use crate::process::operator::map::MapFuncGen;
     use crate::process::operator::tests::{
@@ -414,13 +414,14 @@ mod tests {
         let mut a_results = vec![];
         let mut b_results = vec![];
         while let Some(Ok(res)) = result.next() {
-            let a_entry = res.get(Some(&"a".into())).unwrap().as_ref();
+            let v = res
+                .get(Some(&"a".into()))
+                .unwrap()
+                .as_graph_vertex()
+                .unwrap();
             let b_entry = res.get(Some(&"b".into())).unwrap().as_ref();
-            match (a_entry, b_entry) {
-                (
-                    Entry::Element(RecordElement::OnGraph(GraphObject::VOrE(v))),
-                    Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))),
-                ) => {
+            match b_entry {
+                Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(val))) => {
                     a_results.push(v.id());
                     b_results.push(val.clone());
                 }
@@ -627,8 +628,8 @@ mod tests {
         while let Some(Ok(res)) = result.next() {
             let a_entry = res.get(Some(&"a_col".into())).unwrap().as_ref();
             let b_entry = res.get(Some(&"b_col".into())).unwrap().as_ref();
-            let v1 = a_entry.as_graph_element().unwrap();
-            let v2 = b_entry.as_graph_element().unwrap();
+            let v1 = a_entry.as_graph_vertex().unwrap();
+            let v2 = b_entry.as_graph_vertex().unwrap();
             results.push(v1.id());
             results.push(v2.id());
         }

--- a/research/query_service/ir/runtime/src/process/operator/mod.rs
+++ b/research/query_service/ir/runtime/src/process/operator/mod.rs
@@ -37,7 +37,7 @@ use pegasus::codec::{Decode, Encode, ReadExt, WriteExt};
 use crate::error::FnExecError;
 use crate::graph::element::{Element, GraphElement};
 use crate::graph::property::{Details, PropKey};
-use crate::process::record::{Entry, ObjectElement, Record};
+use crate::process::record::{CommonObject, Entry, Record};
 
 #[derive(Clone, Debug, Default)]
 pub struct TagKey {
@@ -87,7 +87,7 @@ impl TagKey {
                     }
                 };
 
-                Ok(Arc::new(ObjectElement::Prop(prop_obj).into()))
+                Ok(Arc::new(CommonObject::Prop(prop_obj).into()))
             } else {
                 Err(FnExecError::get_tag_error(
                     "Get key failed when attempt to get prop_key from a non-graph element",
@@ -191,7 +191,7 @@ pub(crate) mod tests {
     fn init_record() -> Record {
         let vertex1 = init_vertex1();
         let vertex2 = init_vertex2();
-        let object3 = ObjectElement::Count(10);
+        let object3 = CommonObject::Count(10);
 
         let mut record = Record::new(vertex1, None);
         record.append(vertex2, Some((0 as KeyId).into()));
@@ -228,7 +228,7 @@ pub(crate) mod tests {
     fn test_get_none_tag_entry() {
         let tag_key = TagKey { tag: None, key: None };
         let record = init_record();
-        let expected = ObjectElement::Count(10).into();
+        let expected = CommonObject::Count(10).into();
         let entry = tag_key.get_entry(&record).unwrap();
         assert_eq!(entry.as_ref().clone(), expected)
     }
@@ -253,7 +253,7 @@ pub(crate) mod tests {
         let record = init_record();
         let entry = tag_key.get_entry(&record).unwrap();
         match entry.as_ref() {
-            Entry::Element(RecordElement::OffGraph(ObjectElement::Prop(obj))) => {
+            Entry::Element(RecordElement::OffGraph(CommonObject::Prop(obj))) => {
                 assert_eq!(obj.clone(), object!(expected));
             }
             _ => {

--- a/research/query_service/ir/runtime/src/process/operator/mod.rs
+++ b/research/query_service/ir/runtime/src/process/operator/mod.rs
@@ -56,7 +56,7 @@ impl TagKey {
             )))?
             .clone();
         if let Some(prop_key) = self.key.as_ref() {
-            if let Some(element) = entry.as_graph_element() {
+            if let Some(element) = entry.as_graph_vertex() {
                 let details = element
                     .details()
                     .ok_or(FnExecError::get_tag_error(
@@ -239,7 +239,7 @@ pub(crate) mod tests {
         let expected = init_vertex2();
         let record = init_record();
         let entry = tag_key.get_entry(&record).unwrap();
-        if let Some(element) = entry.as_graph_element() {
+        if let Some(element) = entry.as_graph_vertex() {
             assert_eq!(element.id(), expected.id());
         } else {
             assert!(false);

--- a/research/query_service/ir/runtime/src/process/operator/shuffle.rs
+++ b/research/query_service/ir/runtime/src/process/operator/shuffle.rs
@@ -47,9 +47,12 @@ impl RecordRouter {
 impl RouteFunction<Record> for RecordRouter {
     fn route(&self, t: &Record) -> FnResult<u64> {
         if let Some(entry) = t.get(self.shuffle_key.as_ref()) {
-            if let Some(vertex_or_edge) = entry.as_graph_element() {
+            if let Some(v) = entry.as_graph_vertex() {
+                self.p.get_partition(&v.id(), self.num_workers)
+            } else if let Some(e) = entry.as_graph_edge() {
+                // shuffle e to the partition that contains other_id
                 self.p
-                    .get_partition(&vertex_or_edge.id(), self.num_workers)
+                    .get_partition(&e.get_other_id(), self.num_workers)
             } else {
                 //TODO(bingqing): deal with other element shuffle
                 Ok(0)

--- a/research/query_service/ir/runtime/src/process/operator/shuffle.rs
+++ b/research/query_service/ir/runtime/src/process/operator/shuffle.rs
@@ -21,7 +21,8 @@ use ir_common::generated::common as common_pb;
 use ir_common::NameOrId;
 use pegasus::api::function::{FnResult, RouteFunction};
 
-use crate::graph::element::GraphElement;
+use crate::error::FnExecError;
+use crate::graph::element::{GraphElement, VertexOrEdge};
 use crate::graph::partitioner::Partitioner;
 use crate::process::record::Record;
 
@@ -53,6 +54,16 @@ impl RouteFunction<Record> for RecordRouter {
                 // shuffle e to the partition that contains other_id
                 self.p
                     .get_partition(&e.get_other_id(), self.num_workers)
+            } else if let Some(p) = entry.as_graph_path() {
+                let path_end = p
+                    .get_path_end()
+                    .ok_or(FnExecError::unexpected_data_error("get path_end failed in shuffle"))?;
+                match path_end {
+                    VertexOrEdge::V(v) => self.p.get_partition(&v.id(), self.num_workers),
+                    VertexOrEdge::E(e) => self
+                        .p
+                        .get_partition(&e.get_other_id(), self.num_workers),
+                }
             } else {
                 //TODO(bingqing): deal with other element shuffle
                 Ok(0)

--- a/research/query_service/ir/runtime/src/process/operator/sink/sink.rs
+++ b/research/query_service/ir/runtime/src/process/operator/sink/sink.rs
@@ -27,7 +27,7 @@ use pegasus::api::function::{FnResult, MapFunction};
 use crate::error::FnGenResult;
 use crate::graph::element::{Edge, GraphElement, GraphObject, Vertex};
 use crate::process::operator::sink::SinkFunctionGen;
-use crate::process::record::{Entry, ObjectElement, Record, RecordElement};
+use crate::process::record::{CommonObject, Entry, Record, RecordElement};
 
 #[derive(Debug)]
 pub struct RecordSinkEncoder {
@@ -83,11 +83,11 @@ impl RecordSinkEncoder {
                 todo!()
             }
             RecordElement::OffGraph(o) => match o {
-                ObjectElement::None => None,
-                ObjectElement::Prop(obj) | ObjectElement::Agg(obj) => {
+                CommonObject::None => None,
+                CommonObject::Prop(obj) | CommonObject::Agg(obj) => {
                     Some(result_pb::element::Inner::Object(obj.clone().into()))
                 }
-                ObjectElement::Count(cnt) => {
+                CommonObject::Count(cnt) => {
                     let item = if *cnt <= (i64::MAX as u64) {
                         common_pb::value::Item::I64(*cnt as i64)
                     } else {

--- a/research/query_service/ir/runtime/src/process/operator/sink/sink.rs
+++ b/research/query_service/ir/runtime/src/process/operator/sink/sink.rs
@@ -25,7 +25,7 @@ use ir_common::NameOrId;
 use pegasus::api::function::{FnResult, MapFunction};
 
 use crate::error::FnGenResult;
-use crate::graph::element::{Edge, GraphElement, GraphObject, Vertex, VertexOrEdge};
+use crate::graph::element::{Edge, GraphElement, GraphObject, Vertex};
 use crate::process::operator::sink::SinkFunctionGen;
 use crate::process::record::{Entry, ObjectElement, Record, RecordElement};
 
@@ -70,16 +70,14 @@ impl RecordSinkEncoder {
 
     fn element_to_pb(&self, e: &RecordElement) -> result_pb::Element {
         let inner = match e {
-            RecordElement::OnGraph(GraphObject::VOrE(vertex_or_edge)) => match vertex_or_edge {
-                VertexOrEdge::V(v) => {
-                    let vertex_pb = self.vertex_to_pb(v);
-                    Some(result_pb::element::Inner::Vertex(vertex_pb))
-                }
-                VertexOrEdge::E(e) => {
-                    let edge_pb = self.edge_to_pb(e);
-                    Some(result_pb::element::Inner::Edge(edge_pb))
-                }
-            },
+            RecordElement::OnGraph(GraphObject::V(v)) => {
+                let vertex_pb = self.vertex_to_pb(v);
+                Some(result_pb::element::Inner::Vertex(vertex_pb))
+            }
+            RecordElement::OnGraph(GraphObject::E(e)) => {
+                let edge_pb = self.edge_to_pb(e);
+                Some(result_pb::element::Inner::Edge(edge_pb))
+            }
             // TODO(bingqing): add path type in result_pb
             RecordElement::OnGraph(GraphObject::P(_)) => {
                 todo!()

--- a/research/query_service/ir/runtime/src/process/operator/sink/sink.rs
+++ b/research/query_service/ir/runtime/src/process/operator/sink/sink.rs
@@ -25,7 +25,7 @@ use ir_common::NameOrId;
 use pegasus::api::function::{FnResult, MapFunction};
 
 use crate::error::FnGenResult;
-use crate::graph::element::{Edge, GraphElement, Vertex, VertexOrEdge};
+use crate::graph::element::{Edge, GraphElement, GraphObject, Vertex, VertexOrEdge};
 use crate::process::operator::sink::SinkFunctionGen;
 use crate::process::record::{Entry, ObjectElement, Record, RecordElement};
 
@@ -70,7 +70,7 @@ impl RecordSinkEncoder {
 
     fn element_to_pb(&self, e: &RecordElement) -> result_pb::Element {
         let inner = match e {
-            RecordElement::OnGraph(vertex_or_edge) => match vertex_or_edge {
+            RecordElement::OnGraph(GraphObject::VOrE(vertex_or_edge)) => match vertex_or_edge {
                 VertexOrEdge::V(v) => {
                     let vertex_pb = self.vertex_to_pb(v);
                     Some(result_pb::element::Inner::Vertex(vertex_pb))
@@ -80,6 +80,10 @@ impl RecordSinkEncoder {
                     Some(result_pb::element::Inner::Edge(edge_pb))
                 }
             },
+            // TODO(bingqing): add path type in result_pb
+            RecordElement::OnGraph(GraphObject::P(_)) => {
+                todo!()
+            }
             RecordElement::OffGraph(o) => match o {
                 ObjectElement::None => None,
                 ObjectElement::Prop(obj) | ObjectElement::Agg(obj) => {

--- a/research/query_service/ir/runtime/src/process/operator/sort/sort.rs
+++ b/research/query_service/ir/runtime/src/process/operator/sort/sort.rs
@@ -126,7 +126,7 @@ mod tests {
         let mut result = sort_test(init_source(), sort_opr);
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id());
             }
         }
@@ -147,7 +147,7 @@ mod tests {
         let mut result = sort_test(init_source(), sort_opr);
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_ids.push(element.id());
             }
         }
@@ -168,7 +168,7 @@ mod tests {
         let mut result = sort_test(init_source(), sort_opr);
         let mut result_name = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 result_name.push(
                     element
                         .details()
@@ -211,7 +211,7 @@ mod tests {
         let mut result = sort_test(source, sort_opr);
         let mut result_name_ages = vec![];
         while let Some(Ok(record)) = result.next() {
-            if let Some(element) = record.get(None).unwrap().as_graph_element() {
+            if let Some(element) = record.get(None).unwrap().as_graph_vertex() {
                 let details = element.details().unwrap();
                 result_name_ages.push((
                     details
@@ -251,7 +251,7 @@ mod tests {
             if let Some(element) = record
                 .get(Some(&"a".into()))
                 .unwrap()
-                .as_graph_element()
+                .as_graph_vertex()
             {
                 result_ids.push(element.id());
             }
@@ -276,7 +276,7 @@ mod tests {
             if let Some(element) = record
                 .get(Some(&"a".into()))
                 .unwrap()
-                .as_graph_element()
+                .as_graph_vertex()
             {
                 result_ids.push(element.id());
             }

--- a/research/query_service/ir/runtime/src/process/record.rs
+++ b/research/query_service/ir/runtime/src/process/record.rs
@@ -519,13 +519,12 @@ impl TryFrom<result_pb::Entry> for Entry {
         if let Some(inner) = entry_pb.inner {
             match inner {
                 result_pb::entry::Inner::Element(e) => Ok(Entry::Element(e.try_into()?)),
-                result_pb::entry::Inner::Collection(c) => {
-                    Ok(Entry::Collection(c.collection.into_iter().map(|e| e.try_into()).collect::<Result<
-                        Vec<_>,
-                        Self::Error,
-                    >>(
-                    )?))
-                }
+                result_pb::entry::Inner::Collection(c) => Ok(Entry::Collection(
+                    c.collection
+                        .into_iter()
+                        .map(|e| e.try_into())
+                        .collect::<Result<Vec<_>, Self::Error>>()?,
+                )),
             }
         } else {
             Err(ParsePbError::EmptyFieldError("entry inner is empty".to_string()))?


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. Add GraphPath struct in Runtime to support path_expand.
2. Refine OnGraph RecordElement, i.e., make it consist of Vertex, Edge, and GraphPath.
3. Simplify PartialEq, PartialOrd, Hash trait implementation for Record etc.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

