### PR TITLE
Add path expand in compiler

### DIFF
--- a/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
+++ b/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
@@ -112,24 +112,21 @@ traversalMethod_has
     ;
 
 // out('str1', ...)
-// out(range(1, 5), 'str1')
+// out('1..5', 'str1')
 traversalMethod_out
 	: 'out' LPAREN stringLiteralList RPAREN
-	| 'out' LPAREN traversalMethod_range (COMMA stringLiteralList)? RPAREN
 	;
 
 // in('str1', ...)
-// in(range(1, 5), 'str1')
+// in('1..5', 'str1')
 traversalMethod_in
 	: 'in' LPAREN stringLiteralList RPAREN
-	| 'in' LPAREN traversalMethod_range (COMMA stringLiteralList)? RPAREN
 	;
 
 // both('str1', ...)
-// both(range(1, 5), 'str1', ...)
+// both('1..5', 'str1', ...)
 traversalMethod_both
 	: 'both' LPAREN stringLiteralList RPAREN
-	| 'both' LPAREN traversalMethod_range (COMMA stringLiteralList)? RPAREN
 	;
 
 // outE('str1', ...), outE().inV()
@@ -291,10 +288,6 @@ traversalMethod_whereby
 traversalMethod_whereby_list
     : traversalMethod_whereby (DOT traversalMethod_whereby)*
     ;
-
-traversalMethod_range
-	: 'range' LPAREN integerLiteral COMMA integerLiteral RPAREN
-	;
 
 traversalMethod_not
     : 'not' LPAREN nestedTraversal RPAREN

--- a/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
+++ b/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
@@ -112,18 +112,24 @@ traversalMethod_has
     ;
 
 // out('str1', ...)
+// out(range(1, 5), 'str1')
 traversalMethod_out
 	: 'out' LPAREN stringLiteralList RPAREN
+	| 'out' LPAREN traversalMethod_range (COMMA stringLiteralList)? RPAREN
 	;
 
 // in('str1', ...)
+// in(range(1, 5), 'str1')
 traversalMethod_in
 	: 'in' LPAREN stringLiteralList RPAREN
+	| 'in' LPAREN traversalMethod_range (COMMA stringLiteralList)? RPAREN
 	;
 
 // both('str1', ...)
+// both(range(1, 5), 'str1', ...)
 traversalMethod_both
 	: 'both' LPAREN stringLiteralList RPAREN
+	| 'both' LPAREN traversalMethod_range (COMMA stringLiteralList)? RPAREN
 	;
 
 // outE('str1', ...), outE().inV()
@@ -285,6 +291,10 @@ traversalMethod_whereby
 traversalMethod_whereby_list
     : traversalMethod_whereby (DOT traversalMethod_whereby)*
     ;
+
+traversalMethod_range
+	: 'range' LPAREN integerLiteral COMMA integerLiteral RPAREN
+	;
 
 traversalMethod_not
     : 'not' LPAREN nestedTraversal RPAREN

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
@@ -426,40 +426,40 @@ public class IrPlan implements Closeable {
             InterOpIllegalArgException, InterOpUnsupportedException, AppendInterOpException {
         ResultCode resultCode;
         IntByReference oprId = new IntByReference(parentId);
-        if (base instanceof ScanFusionOp) {
+        if (ClassUtils.equalClass(base, ScanFusionOp.class)) {
             Pointer ptrScan = TransformFactory.SCAN_FUSION_OP.apply(base);
             resultCode = irCoreLib.appendScanOperator(ptrPlan, ptrScan, oprId.getValue(), oprId);
-        } else if (base instanceof SelectOp) {
+        } else if (ClassUtils.equalClass(base, SelectOp.class)) {
             Pointer ptrSelect = TransformFactory.SELECT_OP.apply(base);
             resultCode = irCoreLib.appendSelectOperator(ptrPlan, ptrSelect, oprId.getValue(), oprId);
-        } else if (base instanceof ExpandOp) {
+        } else if (ClassUtils.equalClass(base, ExpandOp.class)) {
             Pointer ptrExpand = TransformFactory.EXPAND_OP.apply(base);
             resultCode = irCoreLib.appendEdgexpdOperator(ptrPlan, ptrExpand, oprId.getValue(), oprId);
-        } else if (base instanceof LimitOp) {
+        } else if (ClassUtils.equalClass(base, LimitOp.class)) {
             Pointer ptrLimit = TransformFactory.LIMIT_OP.apply(base);
             resultCode = irCoreLib.appendLimitOperator(ptrPlan, ptrLimit, oprId.getValue(), oprId);
-        } else if (base instanceof ProjectOp) {
+        } else if (ClassUtils.equalClass(base, ProjectOp.class)) {
             Pointer ptrProject = TransformFactory.PROJECT_OP.apply(base);
             resultCode = irCoreLib.appendProjectOperator(ptrPlan, ptrProject, oprId.getValue(), oprId);
-        } else if (base instanceof OrderOp) {
+        } else if (ClassUtils.equalClass(base, OrderOp.class)) {
             Pointer ptrOrder = TransformFactory.ORDER_OP.apply(base);
             resultCode = irCoreLib.appendOrderbyOperator(ptrPlan, ptrOrder, oprId.getValue(), oprId);
-        } else if (base instanceof GroupOp) {
+        } else if (ClassUtils.equalClass(base, GroupOp.class)) {
             Pointer ptrGroup = TransformFactory.GROUP_OP.apply(base);
             resultCode = irCoreLib.appendGroupbyOperator(ptrPlan, ptrGroup, oprId.getValue(), oprId);
-        } else if (base instanceof DedupOp) {
+        } else if (ClassUtils.equalClass(base, DedupOp.class)) {
             Pointer ptrDedup = TransformFactory.DEDUP_OP.apply(base);
             resultCode = irCoreLib.appendDedupOperator(ptrPlan, ptrDedup, oprId.getValue(), oprId);
-        } else if (base instanceof SinkOp) {
+        } else if (ClassUtils.equalClass(base, SinkOp.class)) {
             Pointer ptrSink = TransformFactory.SINK_OP.apply(base);
             resultCode = irCoreLib.appendSinkOperator(ptrPlan, ptrSink, oprId.getValue(), oprId);
-        } else if (base instanceof PathExpandOp) {
+        } else if (ClassUtils.equalClass(base, PathExpandOp.class)) {
             Pointer ptrPathXPd = TransformFactory.PATH_EXPAND_OP.apply(base);
             resultCode = irCoreLib.appendPathxpdOperator(ptrPlan, ptrPathXPd, oprId.getValue(), oprId);
-        } else if (base instanceof GetVOp) {
+        } else if (ClassUtils.equalClass(base, GetVOp.class)) {
             Pointer ptrGetV = TransformFactory.GETV_OP.apply(base);
             resultCode = irCoreLib.appendGetvOperator(ptrPlan, ptrGetV, oprId.getValue(), oprId);
-        } else if (base instanceof ApplyOp) {
+        } else if (ClassUtils.equalClass(base, ApplyOp.class)) {
             ApplyOp applyOp = (ApplyOp) base;
             Optional<OpArg> subOps = applyOp.getSubOpCollection();
             if (!subOps.isPresent()) {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/PathExpandOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/PathExpandOp.java
@@ -14,6 +14,10 @@ public class PathExpandOp extends ExpandOp {
     }
 
     public PathExpandOp(ExpandOp other) {
+        super();
+        lower = Optional.empty();
+        upper = Optional.empty();
+
         if (other.getAlias().isPresent()) {
             setAlias(other.getAlias().get());
         }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/PathExpandOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/PathExpandOp.java
@@ -1,0 +1,55 @@
+package com.alibaba.graphscope.common.intermediate.operator;
+
+import java.util.Optional;
+
+public class PathExpandOp extends ExpandOp {
+    private Optional<OpArg> lower;
+
+    private Optional<OpArg> upper;
+
+    public PathExpandOp() {
+        super();
+        lower = Optional.empty();
+        upper = Optional.empty();
+    }
+
+    public PathExpandOp(ExpandOp other) {
+        if (other.getAlias().isPresent()) {
+            setAlias(other.getAlias().get());
+        }
+        if (other.getIsEdge().isPresent()) {
+            setEdgeOpt(other.getIsEdge().get());
+        }
+        if (other.getDirection().isPresent()) {
+            setDirection(other.getDirection().get());
+        }
+        if (other.getLabels().isPresent()) {
+            setLabels(other.getLabels().get());
+        }
+        if (other.getPredicate().isPresent()) {
+            setPredicate(other.getPredicate().get());
+        }
+        if (other.getProperties().isPresent()) {
+            setProperties(other.getProperties().get());
+        }
+        if (other.getLimit().isPresent()) {
+            setLimit(other.getLimit().get());
+        }
+    }
+
+    public Optional<OpArg> getLower() {
+        return lower;
+    }
+
+    public Optional<OpArg> getUpper() {
+        return upper;
+    }
+
+    public void setLower(OpArg lower) {
+        this.lower = Optional.of(lower);
+    }
+
+    public void setUpper(OpArg upper) {
+        this.upper = Optional.of(upper);
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/PathExpandOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/PathExpandOp.java
@@ -14,10 +14,7 @@ public class PathExpandOp extends ExpandOp {
     }
 
     public PathExpandOp(ExpandOp other) {
-        super();
-        lower = Optional.empty();
-        upper = Optional.empty();
-
+        this();
         if (other.getAlias().isPresent()) {
             setAlias(other.getAlias().get());
         }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/IrCoreLibrary.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/IrCoreLibrary.java
@@ -130,6 +130,14 @@ public interface IrCoreLibrary extends Library {
 
     ResultCode appendApplyOperator(Pointer plan, Pointer apply, int parent, IntByReference oprIdx);
 
+    Pointer initPathxpdOperator(Pointer expand, boolean isWholePath);
+
+    ResultCode setPathxpdAlias(Pointer pathXpd, FfiAlias.ByValue alias);
+
+    ResultCode setPathxpdHops(Pointer pathXpd, int lower, int upper);
+
+    ResultCode appendPathxpdOperator(Pointer plan, Pointer pathXpd, int parent, IntByReference oprIdx);
+
     FfiNameOrId.ByValue noneNameOrId();
 
     FfiNameOrId.ByValue cstrAsNameOrId(String name);

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/utils/ClassUtils.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/utils/ClassUtils.java
@@ -1,0 +1,7 @@
+package com.alibaba.graphscope.common.utils;
+
+public class ClassUtils {
+    public static <T> boolean equalClass(T t1, Class<? extends T> target) {
+        return t1.getClass().equals(target);
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/InterOpCollectionBuilder.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/InterOpCollectionBuilder.java
@@ -22,6 +22,7 @@ import com.alibaba.graphscope.common.jna.type.FfiJoinKind;
 import com.alibaba.graphscope.gremlin.exception.UnsupportedStepException;
 import com.alibaba.graphscope.common.intermediate.operator.*;
 import com.alibaba.graphscope.common.jna.type.FfiScanOpt;
+import com.alibaba.graphscope.gremlin.plugin.step.PathExpandStep;
 import com.alibaba.graphscope.gremlin.transform.OpArgTransformFactory;
 import com.alibaba.graphscope.gremlin.transform.PredicateExprTransformFactory;
 import com.alibaba.graphscope.gremlin.transform.ProjectTraversalTransformFactory;
@@ -327,6 +328,16 @@ public class InterOpCollectionBuilder {
                 return op;
             }
         },
+        PATH_EXPAND_STEP {
+            @Override
+            public InterOpBase apply(Step step) {
+                PathExpandOp op = new PathExpandOp((ExpandOp) VERTEX_STEP.apply(step));
+                PathExpandStep pathStep = (PathExpandStep) step;
+                op.setLower(new OpArg(Integer.valueOf(pathStep.getLower() + 1), Function.identity()));
+                op.setUpper(new OpArg(Integer.valueOf(pathStep.getUpper() + 1), Function.identity()));
+                return op;
+            }
+        },
         EDGE_VERTEX_STEP {
             @Override
             public InterOpBase apply(Step step) {
@@ -462,6 +473,8 @@ public class InterOpCollectionBuilder {
                 op = StepTransformFactory.EDGE_VERTEX_STEP.apply(step);
             } else if (Utils.equalClass(step, EdgeOtherVertexStep.class)) {
                 op = StepTransformFactory.EDGE_OTHER_STEP.apply(step);
+            } else if (Utils.equalClass(step, PathExpandStep.class)) {
+                op = StepTransformFactory.PATH_EXPAND_STEP.apply(step);
             } else if (Utils.equalClass(step, WherePredicateStep.class)) {
                 op = StepTransformFactory.WHERE_PREDICATE_STEP.apply(step);
             } else if (Utils.equalClass(step, TraversalFilterStep.class)

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/Utils.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/Utils.java
@@ -16,16 +16,16 @@
 
 package com.alibaba.graphscope.gremlin;
 
+import com.alibaba.graphscope.common.utils.ClassUtils;
 import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
-import org.apache.tinkerpop.gremlin.process.traversal.Step;
 
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.charset.StandardCharsets;
 
-public class Utils {
+public class Utils extends ClassUtils {
     /**
      * Set private field with given value
      *
@@ -76,9 +76,5 @@ public class Utils {
 
     public static String readStringFromFile(String filePath) throws IOException {
         return FileUtils.readFileToString(new File(filePath), StandardCharsets.UTF_8);
-    }
-
-    public static boolean equalClass(Step t1, Class<? extends Step> target) {
-        return t1.getClass().equals(target);
     }
 }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/exception/ExtendGremlinStepException.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/exception/ExtendGremlinStepException.java
@@ -1,0 +1,7 @@
+package com.alibaba.graphscope.gremlin.exception;
+
+public class ExtendGremlinStepException extends IllegalArgumentException {
+    public ExtendGremlinStepException(String error) {
+        super(error);
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
@@ -32,6 +32,7 @@ import com.alibaba.graphscope.common.config.PegasusConfig;
 import com.alibaba.graphscope.common.intermediate.InterOpCollection;
 import com.alibaba.graphscope.gremlin.InterOpCollectionBuilder;
 import com.alibaba.graphscope.gremlin.plugin.script.AntlrToJavaScriptEngineFactory;
+import com.alibaba.graphscope.gremlin.plugin.traversal.IrCustomizedTraversalSource;
 import com.alibaba.graphscope.gremlin.result.GremlinResultAnalyzer;
 import com.alibaba.graphscope.gremlin.result.GremlinResultProcessor;
 import com.alibaba.pegasus.service.protocol.PegasusClient;
@@ -74,7 +75,7 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
 
     public IrStandardOpProcessor(Configs configs) {
         this.graph = TinkerFactory.createModern();
-        this.g = graph.traversal();
+        this.g = graph.traversal(IrCustomizedTraversalSource.class);
         this.configs = configs;
         RpcChannelFetcher channelFetcher = new HostsChannelFetcher(configs);
         broadcastProcessor = new RpcBroadcastProcessor(channelFetcher);

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/step/PathExpandStep.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/step/PathExpandStep.java
@@ -1,0 +1,80 @@
+package com.alibaba.graphscope.gremlin.plugin.step;
+
+import com.alibaba.graphscope.gremlin.exception.ExtendGremlinStepException;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
+import org.apache.tinkerpop.gremlin.process.traversal.step.Configuring;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.FlatMapStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+import java.util.Iterator;
+
+public class PathExpandStep<E extends Element> extends FlatMapStep<Vertex, E> implements AutoCloseable, Configuring {
+    private String[] edgeLabels;
+    private Direction direction;
+    private Traversal rangeTraversal;
+
+    public PathExpandStep(final Traversal.Admin traversal, final Direction direction,
+                          final Traversal rangeTraversal, final String... edgeLabels) {
+        super(traversal);
+        this.direction = direction;
+        this.rangeTraversal = rangeTraversal;
+        this.edgeLabels = edgeLabels;
+    }
+
+    public Direction getDirection() {
+        return this.direction;
+    }
+
+    public String[] getEdgeLabels() {
+        return this.edgeLabels;
+    }
+
+    public int getLower() {
+        Traversal.Admin admin = rangeTraversal.asAdmin();
+        if (admin.getSteps().size() == 1 && admin.getStartStep() instanceof RangeGlobalStep) {
+            RangeGlobalStep range = (RangeGlobalStep) admin.getStartStep();
+            return (int) range.getLowRange();
+        } else {
+            throw new ExtendGremlinStepException("rangeTraversal should only have one RangeGlobalStep");
+        }
+    }
+
+    public int getUpper() {
+        Traversal.Admin admin = rangeTraversal.asAdmin();
+        if (admin.getSteps().size() == 1 && admin.getStartStep() instanceof RangeGlobalStep) {
+            RangeGlobalStep range = (RangeGlobalStep) admin.getStartStep();
+            return (int) range.getHighRange();
+        } else {
+            throw new ExtendGremlinStepException("rangeTraversal should only have one RangeGlobalStep");
+        }
+    }
+
+    public boolean returnsVertex() {
+        return true;
+    }
+
+    @Override
+    public void close() {
+        throw new ExtendGremlinStepException("unsupported");
+    }
+
+    @Override
+    protected Iterator<E> flatMap(Traverser.Admin<Vertex> traverser) {
+        throw new ExtendGremlinStepException("unsupported");
+    }
+
+    @Override
+    public void configure(Object... keyValues) {
+        throw new ExtendGremlinStepException("unsupported");
+    }
+
+    @Override
+    public Parameters getParameters() {
+        throw new ExtendGremlinStepException("unsupported");
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/step/PathExpandStep.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/step/PathExpandStep.java
@@ -3,24 +3,22 @@ package com.alibaba.graphscope.gremlin.plugin.step;
 import com.alibaba.graphscope.gremlin.exception.ExtendGremlinStepException;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traverser;
-import org.apache.tinkerpop.gremlin.process.traversal.step.Configuring;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.RangeGlobalStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.FlatMapStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.Parameters;
 import org.apache.tinkerpop.gremlin.structure.Direction;
-import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 
 import java.util.Iterator;
 
-public class PathExpandStep<E extends Element> extends FlatMapStep<Vertex, E> implements AutoCloseable, Configuring {
+public class PathExpandStep extends VertexStep<Vertex> {
     private String[] edgeLabels;
     private Direction direction;
     private Traversal rangeTraversal;
 
     public PathExpandStep(final Traversal.Admin traversal, final Direction direction,
                           final Traversal rangeTraversal, final String... edgeLabels) {
-        super(traversal);
+        super(traversal, Vertex.class, direction, edgeLabels);
         this.direction = direction;
         this.rangeTraversal = rangeTraversal;
         this.edgeLabels = edgeLabels;
@@ -54,17 +52,13 @@ public class PathExpandStep<E extends Element> extends FlatMapStep<Vertex, E> im
         }
     }
 
-    public boolean returnsVertex() {
-        return true;
-    }
-
     @Override
     public void close() {
         throw new ExtendGremlinStepException("unsupported");
     }
 
     @Override
-    protected Iterator<E> flatMap(Traverser.Admin<Vertex> traverser) {
+    protected Iterator<Vertex> flatMap(Traverser.Admin<Vertex> traverser) {
         throw new ExtendGremlinStepException("unsupported");
     }
 

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/traversal/IrCustomizedTraversal.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/traversal/IrCustomizedTraversal.java
@@ -1,0 +1,54 @@
+package com.alibaba.graphscope.gremlin.plugin.traversal;
+
+import com.alibaba.graphscope.gremlin.plugin.step.PathExpandStep;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.util.DefaultTraversal;
+import org.apache.tinkerpop.gremlin.structure.Direction;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+
+public class IrCustomizedTraversal<S, E> extends DefaultTraversal<S, E> implements GraphTraversal.Admin<S, E> {
+    public IrCustomizedTraversal() {
+        super();
+    }
+
+    public IrCustomizedTraversal(final GraphTraversalSource graphTraversalSource) {
+        super(graphTraversalSource);
+    }
+
+    public IrCustomizedTraversal(final Graph graph) {
+        super(graph);
+    }
+
+    @Override
+    public GraphTraversal.Admin<S, E> asAdmin() {
+        return this;
+    }
+
+    @Override
+    public GraphTraversal<S, E> iterate() {
+        return GraphTraversal.Admin.super.iterate();
+    }
+
+    @Override
+    public IrCustomizedTraversal<S, E> clone() {
+        return (IrCustomizedTraversal<S, E>) super.clone();
+    }
+
+    public GraphTraversal<S, Vertex> out(Traversal rangeTraversal, String... labels) {
+        this.asAdmin().getBytecode().addStep("flatMap", rangeTraversal, labels);
+        return this.asAdmin().addStep(new PathExpandStep(this.asAdmin(), Direction.OUT, rangeTraversal, labels));
+    }
+
+    public GraphTraversal<S, Vertex> in(Traversal rangeTraversal, String... labels) {
+        this.asAdmin().getBytecode().addStep("flatMap", rangeTraversal, labels);
+        return this.asAdmin().addStep(new PathExpandStep(this.asAdmin(), Direction.IN, rangeTraversal, labels));
+    }
+
+    public GraphTraversal<S, Vertex> both(Traversal rangeTraversal, String... labels) {
+        this.asAdmin().getBytecode().addStep("flatMap", rangeTraversal, labels);
+        return this.asAdmin().addStep(new PathExpandStep(this.asAdmin(), Direction.BOTH, rangeTraversal, labels));
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/traversal/IrCustomizedTraversalSource.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/traversal/IrCustomizedTraversalSource.java
@@ -1,31 +1,15 @@
 package com.alibaba.graphscope.gremlin.plugin.traversal;
 
-import org.apache.tinkerpop.gremlin.process.computer.Computer;
-import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
 import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
-import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal.Admin;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
 import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies.GlobalCache;
-import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStartStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectStep;
-import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.IoStep;
-import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.RequirementsStrategy;
-import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
 import org.apache.tinkerpop.gremlin.structure.Edge;
 import org.apache.tinkerpop.gremlin.structure.Graph;
-import org.apache.tinkerpop.gremlin.structure.Transaction;
 import org.apache.tinkerpop.gremlin.structure.Vertex;
 import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
-
-import java.util.function.BinaryOperator;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 
 public class IrCustomizedTraversalSource extends GraphTraversalSource {
     public IrCustomizedTraversalSource(final Graph graph, final TraversalStrategies traversalStrategies) {
@@ -40,6 +24,7 @@ public class IrCustomizedTraversalSource extends GraphTraversalSource {
         super(connection);
     }
 
+    @Override
     public IrCustomizedTraversalSource clone() {
         IrCustomizedTraversalSource clone = (IrCustomizedTraversalSource) super.clone();
         clone.strategies = this.strategies.clone();
@@ -47,142 +32,7 @@ public class IrCustomizedTraversalSource extends GraphTraversalSource {
         return clone;
     }
 
-    public IrCustomizedTraversalSource with(final String key) {
-        return (IrCustomizedTraversalSource) super.with(key);
-    }
-
-    public IrCustomizedTraversalSource with(final String key, final Object value) {
-        return (IrCustomizedTraversalSource) super.with(key, value);
-    }
-
-    public IrCustomizedTraversalSource withStrategies(final TraversalStrategy... traversalStrategies) {
-        return (IrCustomizedTraversalSource) super.withStrategies(traversalStrategies);
-    }
-
-    public IrCustomizedTraversalSource withoutStrategies(final Class<? extends TraversalStrategy>... traversalStrategyClasses) {
-        return (IrCustomizedTraversalSource) super.withoutStrategies(traversalStrategyClasses);
-    }
-
-    public IrCustomizedTraversalSource withComputer(final Computer computer) {
-        return (IrCustomizedTraversalSource) super.withComputer(computer);
-    }
-
-    public IrCustomizedTraversalSource withComputer(final Class<? extends GraphComputer> graphComputerClass) {
-        return (IrCustomizedTraversalSource) super.withComputer(graphComputerClass);
-    }
-
-    public IrCustomizedTraversalSource withComputer() {
-        return (IrCustomizedTraversalSource) super.withComputer();
-    }
-
-    public <A> IrCustomizedTraversalSource withSideEffect(final String key, final Supplier<A> initialValue, final BinaryOperator<A> reducer) {
-        return (IrCustomizedTraversalSource) super.withSideEffect(key, initialValue, reducer);
-    }
-
-    public <A> IrCustomizedTraversalSource withSideEffect(final String key, final A initialValue, final BinaryOperator<A> reducer) {
-        return (IrCustomizedTraversalSource) super.withSideEffect(key, initialValue, reducer);
-    }
-
-    public <A> IrCustomizedTraversalSource withSideEffect(final String key, final A initialValue) {
-        return (IrCustomizedTraversalSource) super.withSideEffect(key, initialValue);
-    }
-
-    public <A> IrCustomizedTraversalSource withSideEffect(final String key, final Supplier<A> initialValue) {
-        return (IrCustomizedTraversalSource) super.withSideEffect(key, initialValue);
-    }
-
-    public <A> IrCustomizedTraversalSource withSack(final Supplier<A> initialValue, final UnaryOperator<A> splitOperator, final BinaryOperator<A> mergeOperator) {
-        return (IrCustomizedTraversalSource) super.withSack(initialValue, splitOperator, mergeOperator);
-    }
-
-    public <A> IrCustomizedTraversalSource withSack(final A initialValue, final UnaryOperator<A> splitOperator, final BinaryOperator<A> mergeOperator) {
-        return (IrCustomizedTraversalSource) super.withSack(initialValue, splitOperator, mergeOperator);
-    }
-
-    public <A> IrCustomizedTraversalSource withSack(final A initialValue) {
-        return (IrCustomizedTraversalSource) super.withSack(initialValue);
-    }
-
-    public <A> IrCustomizedTraversalSource withSack(final Supplier<A> initialValue) {
-        return (IrCustomizedTraversalSource) super.withSack(initialValue);
-    }
-
-    public <A> IrCustomizedTraversalSource withSack(final Supplier<A> initialValue, final UnaryOperator<A> splitOperator) {
-        return (IrCustomizedTraversalSource) super.withSack(initialValue, splitOperator);
-    }
-
-    public <A> IrCustomizedTraversalSource withSack(final A initialValue, final UnaryOperator<A> splitOperator) {
-        return (IrCustomizedTraversalSource) super.withSack(initialValue, splitOperator);
-    }
-
-    public <A> IrCustomizedTraversalSource withSack(final Supplier<A> initialValue, final BinaryOperator<A> mergeOperator) {
-        return (IrCustomizedTraversalSource) super.withSack(initialValue, mergeOperator);
-    }
-
-    public <A> IrCustomizedTraversalSource withSack(final A initialValue, final BinaryOperator<A> mergeOperator) {
-        return (IrCustomizedTraversalSource) super.withSack(initialValue, mergeOperator);
-    }
-
-    public IrCustomizedTraversalSource withBulk(final boolean useBulk) {
-        if (useBulk) {
-            return this;
-        } else {
-            IrCustomizedTraversalSource clone = this.clone();
-            RequirementsStrategy.addRequirements(clone.getStrategies(), new TraverserRequirement[]{TraverserRequirement.ONE_BULK});
-            clone.bytecode.addSource("withBulk", new Object[]{useBulk});
-            return clone;
-        }
-    }
-
-    public IrCustomizedTraversalSource withPath() {
-        IrCustomizedTraversalSource clone = this.clone();
-        RequirementsStrategy.addRequirements(clone.getStrategies(), new TraverserRequirement[]{TraverserRequirement.PATH});
-        clone.bytecode.addSource("withPath", new Object[0]);
-        return clone;
-    }
-
-    public GraphTraversal<Vertex, Vertex> addV(final String label) {
-        IrCustomizedTraversalSource clone = this.clone();
-        clone.bytecode.addStep("addV", new Object[]{label});
-        Admin<Vertex, Vertex> traversal = new IrCustomizedTraversal(clone);
-        return (GraphTraversal<Vertex, Vertex>) traversal.addStep(new AddVertexStartStep(traversal, label));
-    }
-
-    public GraphTraversal<Vertex, Vertex> addV(final Traversal<?, String> vertexLabelTraversal) {
-        IrCustomizedTraversalSource clone = this.clone();
-        clone.bytecode.addStep("addV", new Object[]{vertexLabelTraversal});
-        Admin<Vertex, Vertex> traversal = new IrCustomizedTraversal(clone);
-        return (GraphTraversal<Vertex, Vertex>) traversal.addStep(new AddVertexStartStep(traversal, vertexLabelTraversal));
-    }
-
-    public GraphTraversal<Vertex, Vertex> addV() {
-        IrCustomizedTraversalSource clone = this.clone();
-        clone.bytecode.addStep("addV", new Object[0]);
-        Admin<Vertex, Vertex> traversal = new IrCustomizedTraversal(clone);
-        return (GraphTraversal<Vertex, Vertex>) traversal.addStep(new AddVertexStartStep(traversal, (String) null));
-    }
-
-    public GraphTraversal<Edge, Edge> addE(final String label) {
-        IrCustomizedTraversalSource clone = this.clone();
-        clone.bytecode.addStep("addE", new Object[]{label});
-        Admin<Edge, Edge> traversal = new IrCustomizedTraversal(clone);
-        return (GraphTraversal<Edge, Edge>) traversal.addStep(new AddEdgeStartStep(traversal, label));
-    }
-
-    public GraphTraversal<Edge, Edge> addE(final Traversal<?, String> edgeLabelTraversal) {
-        IrCustomizedTraversalSource clone = this.clone();
-        clone.bytecode.addStep("addE", new Object[]{edgeLabelTraversal});
-        Admin<Edge, Edge> traversal = new IrCustomizedTraversal(clone);
-        return (GraphTraversal<Edge, Edge>) traversal.addStep(new AddEdgeStartStep(traversal, edgeLabelTraversal));
-    }
-
-    public <S> GraphTraversal<S, S> inject(S... starts) {
-        IrCustomizedTraversalSource clone = this.clone();
-        clone.bytecode.addStep("inject", starts);
-        Admin<S, S> traversal = new IrCustomizedTraversal(clone);
-        return (GraphTraversal<S, S>) traversal.addStep(new InjectStep(traversal, starts));
-    }
-
+    @Override
     public IrCustomizedTraversal<Vertex, Vertex> V(final Object... vertexIds) {
         IrCustomizedTraversalSource clone = this.clone();
         clone.bytecode.addStep("V", vertexIds);
@@ -190,6 +40,7 @@ public class IrCustomizedTraversalSource extends GraphTraversalSource {
         return (IrCustomizedTraversal<Vertex, Vertex>) traversal.addStep(new GraphStep(traversal, Vertex.class, true, vertexIds));
     }
 
+    @Override
     public IrCustomizedTraversal<Edge, Edge> E(final Object... edgesIds) {
         IrCustomizedTraversalSource clone = this.clone();
         clone.bytecode.addStep("E", edgesIds);
@@ -197,17 +48,7 @@ public class IrCustomizedTraversalSource extends GraphTraversalSource {
         return (IrCustomizedTraversal<Edge, Edge>) traversal.addStep(new GraphStep(traversal, Edge.class, true, edgesIds));
     }
 
-    public <S> GraphTraversal<S, S> io(final String file) {
-        IrCustomizedTraversalSource clone = this.clone();
-        clone.bytecode.addStep("io", new Object[]{file});
-        Admin<S, S> traversal = new IrCustomizedTraversal(clone);
-        return (GraphTraversal<S, S>) traversal.addStep(new IoStep(traversal, file));
-    }
-
-    public Transaction tx() {
-        return this.graph.tx();
-    }
-
+    @Override
     public void close() throws Exception {
         if (this.connection != null) {
             this.connection.close();
@@ -215,6 +56,7 @@ public class IrCustomizedTraversalSource extends GraphTraversalSource {
 
     }
 
+    @Override
     public String toString() {
         return StringFactory.traversalSourceString(this);
     }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/traversal/IrCustomizedTraversalSource.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/traversal/IrCustomizedTraversalSource.java
@@ -1,0 +1,221 @@
+package com.alibaba.graphscope.gremlin.plugin.traversal;
+
+import org.apache.tinkerpop.gremlin.process.computer.Computer;
+import org.apache.tinkerpop.gremlin.process.computer.GraphComputer;
+import org.apache.tinkerpop.gremlin.process.remote.RemoteConnection;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal.Admin;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategies.GlobalCache;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddEdgeStartStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.AddVertexStartStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.InjectStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.sideEffect.IoStep;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.RequirementsStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.traverser.TraverserRequirement;
+import org.apache.tinkerpop.gremlin.structure.Edge;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.structure.Transaction;
+import org.apache.tinkerpop.gremlin.structure.Vertex;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+
+import java.util.function.BinaryOperator;
+import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
+
+public class IrCustomizedTraversalSource extends GraphTraversalSource {
+    public IrCustomizedTraversalSource(final Graph graph, final TraversalStrategies traversalStrategies) {
+        super(graph, traversalStrategies);
+    }
+
+    public IrCustomizedTraversalSource(final Graph graph) {
+        this(graph, GlobalCache.getStrategies(graph.getClass()));
+    }
+
+    public IrCustomizedTraversalSource(final RemoteConnection connection) {
+        super(connection);
+    }
+
+    public IrCustomizedTraversalSource clone() {
+        IrCustomizedTraversalSource clone = (IrCustomizedTraversalSource) super.clone();
+        clone.strategies = this.strategies.clone();
+        clone.bytecode = this.bytecode.clone();
+        return clone;
+    }
+
+    public IrCustomizedTraversalSource with(final String key) {
+        return (IrCustomizedTraversalSource) super.with(key);
+    }
+
+    public IrCustomizedTraversalSource with(final String key, final Object value) {
+        return (IrCustomizedTraversalSource) super.with(key, value);
+    }
+
+    public IrCustomizedTraversalSource withStrategies(final TraversalStrategy... traversalStrategies) {
+        return (IrCustomizedTraversalSource) super.withStrategies(traversalStrategies);
+    }
+
+    public IrCustomizedTraversalSource withoutStrategies(final Class<? extends TraversalStrategy>... traversalStrategyClasses) {
+        return (IrCustomizedTraversalSource) super.withoutStrategies(traversalStrategyClasses);
+    }
+
+    public IrCustomizedTraversalSource withComputer(final Computer computer) {
+        return (IrCustomizedTraversalSource) super.withComputer(computer);
+    }
+
+    public IrCustomizedTraversalSource withComputer(final Class<? extends GraphComputer> graphComputerClass) {
+        return (IrCustomizedTraversalSource) super.withComputer(graphComputerClass);
+    }
+
+    public IrCustomizedTraversalSource withComputer() {
+        return (IrCustomizedTraversalSource) super.withComputer();
+    }
+
+    public <A> IrCustomizedTraversalSource withSideEffect(final String key, final Supplier<A> initialValue, final BinaryOperator<A> reducer) {
+        return (IrCustomizedTraversalSource) super.withSideEffect(key, initialValue, reducer);
+    }
+
+    public <A> IrCustomizedTraversalSource withSideEffect(final String key, final A initialValue, final BinaryOperator<A> reducer) {
+        return (IrCustomizedTraversalSource) super.withSideEffect(key, initialValue, reducer);
+    }
+
+    public <A> IrCustomizedTraversalSource withSideEffect(final String key, final A initialValue) {
+        return (IrCustomizedTraversalSource) super.withSideEffect(key, initialValue);
+    }
+
+    public <A> IrCustomizedTraversalSource withSideEffect(final String key, final Supplier<A> initialValue) {
+        return (IrCustomizedTraversalSource) super.withSideEffect(key, initialValue);
+    }
+
+    public <A> IrCustomizedTraversalSource withSack(final Supplier<A> initialValue, final UnaryOperator<A> splitOperator, final BinaryOperator<A> mergeOperator) {
+        return (IrCustomizedTraversalSource) super.withSack(initialValue, splitOperator, mergeOperator);
+    }
+
+    public <A> IrCustomizedTraversalSource withSack(final A initialValue, final UnaryOperator<A> splitOperator, final BinaryOperator<A> mergeOperator) {
+        return (IrCustomizedTraversalSource) super.withSack(initialValue, splitOperator, mergeOperator);
+    }
+
+    public <A> IrCustomizedTraversalSource withSack(final A initialValue) {
+        return (IrCustomizedTraversalSource) super.withSack(initialValue);
+    }
+
+    public <A> IrCustomizedTraversalSource withSack(final Supplier<A> initialValue) {
+        return (IrCustomizedTraversalSource) super.withSack(initialValue);
+    }
+
+    public <A> IrCustomizedTraversalSource withSack(final Supplier<A> initialValue, final UnaryOperator<A> splitOperator) {
+        return (IrCustomizedTraversalSource) super.withSack(initialValue, splitOperator);
+    }
+
+    public <A> IrCustomizedTraversalSource withSack(final A initialValue, final UnaryOperator<A> splitOperator) {
+        return (IrCustomizedTraversalSource) super.withSack(initialValue, splitOperator);
+    }
+
+    public <A> IrCustomizedTraversalSource withSack(final Supplier<A> initialValue, final BinaryOperator<A> mergeOperator) {
+        return (IrCustomizedTraversalSource) super.withSack(initialValue, mergeOperator);
+    }
+
+    public <A> IrCustomizedTraversalSource withSack(final A initialValue, final BinaryOperator<A> mergeOperator) {
+        return (IrCustomizedTraversalSource) super.withSack(initialValue, mergeOperator);
+    }
+
+    public IrCustomizedTraversalSource withBulk(final boolean useBulk) {
+        if (useBulk) {
+            return this;
+        } else {
+            IrCustomizedTraversalSource clone = this.clone();
+            RequirementsStrategy.addRequirements(clone.getStrategies(), new TraverserRequirement[]{TraverserRequirement.ONE_BULK});
+            clone.bytecode.addSource("withBulk", new Object[]{useBulk});
+            return clone;
+        }
+    }
+
+    public IrCustomizedTraversalSource withPath() {
+        IrCustomizedTraversalSource clone = this.clone();
+        RequirementsStrategy.addRequirements(clone.getStrategies(), new TraverserRequirement[]{TraverserRequirement.PATH});
+        clone.bytecode.addSource("withPath", new Object[0]);
+        return clone;
+    }
+
+    public GraphTraversal<Vertex, Vertex> addV(final String label) {
+        IrCustomizedTraversalSource clone = this.clone();
+        clone.bytecode.addStep("addV", new Object[]{label});
+        Admin<Vertex, Vertex> traversal = new IrCustomizedTraversal(clone);
+        return (GraphTraversal<Vertex, Vertex>) traversal.addStep(new AddVertexStartStep(traversal, label));
+    }
+
+    public GraphTraversal<Vertex, Vertex> addV(final Traversal<?, String> vertexLabelTraversal) {
+        IrCustomizedTraversalSource clone = this.clone();
+        clone.bytecode.addStep("addV", new Object[]{vertexLabelTraversal});
+        Admin<Vertex, Vertex> traversal = new IrCustomizedTraversal(clone);
+        return (GraphTraversal<Vertex, Vertex>) traversal.addStep(new AddVertexStartStep(traversal, vertexLabelTraversal));
+    }
+
+    public GraphTraversal<Vertex, Vertex> addV() {
+        IrCustomizedTraversalSource clone = this.clone();
+        clone.bytecode.addStep("addV", new Object[0]);
+        Admin<Vertex, Vertex> traversal = new IrCustomizedTraversal(clone);
+        return (GraphTraversal<Vertex, Vertex>) traversal.addStep(new AddVertexStartStep(traversal, (String) null));
+    }
+
+    public GraphTraversal<Edge, Edge> addE(final String label) {
+        IrCustomizedTraversalSource clone = this.clone();
+        clone.bytecode.addStep("addE", new Object[]{label});
+        Admin<Edge, Edge> traversal = new IrCustomizedTraversal(clone);
+        return (GraphTraversal<Edge, Edge>) traversal.addStep(new AddEdgeStartStep(traversal, label));
+    }
+
+    public GraphTraversal<Edge, Edge> addE(final Traversal<?, String> edgeLabelTraversal) {
+        IrCustomizedTraversalSource clone = this.clone();
+        clone.bytecode.addStep("addE", new Object[]{edgeLabelTraversal});
+        Admin<Edge, Edge> traversal = new IrCustomizedTraversal(clone);
+        return (GraphTraversal<Edge, Edge>) traversal.addStep(new AddEdgeStartStep(traversal, edgeLabelTraversal));
+    }
+
+    public <S> GraphTraversal<S, S> inject(S... starts) {
+        IrCustomizedTraversalSource clone = this.clone();
+        clone.bytecode.addStep("inject", starts);
+        Admin<S, S> traversal = new IrCustomizedTraversal(clone);
+        return (GraphTraversal<S, S>) traversal.addStep(new InjectStep(traversal, starts));
+    }
+
+    public IrCustomizedTraversal<Vertex, Vertex> V(final Object... vertexIds) {
+        IrCustomizedTraversalSource clone = this.clone();
+        clone.bytecode.addStep("V", vertexIds);
+        Admin<Vertex, Vertex> traversal = new IrCustomizedTraversal(clone);
+        return (IrCustomizedTraversal<Vertex, Vertex>) traversal.addStep(new GraphStep(traversal, Vertex.class, true, vertexIds));
+    }
+
+    public IrCustomizedTraversal<Edge, Edge> E(final Object... edgesIds) {
+        IrCustomizedTraversalSource clone = this.clone();
+        clone.bytecode.addStep("E", edgesIds);
+        Admin<Edge, Edge> traversal = new IrCustomizedTraversal(clone);
+        return (IrCustomizedTraversal<Edge, Edge>) traversal.addStep(new GraphStep(traversal, Edge.class, true, edgesIds));
+    }
+
+    public <S> GraphTraversal<S, S> io(final String file) {
+        IrCustomizedTraversalSource clone = this.clone();
+        clone.bytecode.addStep("io", new Object[]{file});
+        Admin<S, S> traversal = new IrCustomizedTraversal(clone);
+        return (GraphTraversal<S, S>) traversal.addStep(new IoStep(traversal, file));
+    }
+
+    public Transaction tx() {
+        return this.graph.tx();
+    }
+
+    public void close() throws Exception {
+        if (this.connection != null) {
+            this.connection.close();
+        }
+
+    }
+
+    public String toString() {
+        return StringFactory.traversalSourceString(this);
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
@@ -2,6 +2,7 @@ package com.alibaba.graphscope.gremlin.result;
 
 import com.alibaba.graphscope.gremlin.Utils;
 import com.alibaba.graphscope.gremlin.exception.UnsupportedStepException;
+import com.alibaba.graphscope.gremlin.plugin.step.PathExpandStep;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.*;
@@ -26,6 +27,8 @@ public class GremlinResultAnalyzer {
                 parserType = GremlinResultParserFactory.PROJECT_VALUE;
             } else if (Utils.equalClass(step, GroupCountStep.class) || Utils.equalClass(step, GroupStep.class)) {
                 parserType = GremlinResultParserFactory.GROUP;
+            } else if (Utils.equalClass(step, PathExpandStep.class)) {
+                parserType = GremlinResultParserFactory.PATH_EXPAND;
             } else if (Utils.equalClass(step, HasStep.class) || Utils.equalClass(step, DedupGlobalStep.class)
                     || Utils.equalClass(step, RangeGlobalStep.class) || Utils.equalClass(step, OrderGlobalStep.class)
                     || Utils.equalClass(step, IsStep.class) || Utils.equalClass(step, WherePredicateStep.class)

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultParserFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultParserFactory.java
@@ -127,6 +127,12 @@ public enum GremlinResultParserFactory implements GremlinResultParser {
                     throw new GremlinResultParserException(entry.getInnerCase() + " is invalid");
             }
         }
+    },
+    PATH_EXPAND {
+        @Override
+        public List<Element> parseFrom(IrResult.Results results) {
+            throw new GremlinResultParserException("the whole path is unsupported yet");
+        }
     };
 
     private static Logger logger = LoggerFactory.getLogger(GremlinResultParserFactory.class);

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
@@ -37,7 +37,7 @@ public class DedupOpTest {
         FfiVariable.ByValue dedupKey = ArgUtils.asNoneVar();
         op.setDedupKeys(new OpArg(Collections.singletonList(dedupKey), Function.identity()));
 
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("dedup.json"), irPlan.getPlanAsJson());
     }
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ExpandOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ExpandOpTest.java
@@ -40,7 +40,7 @@ public class ExpandOpTest {
         ExpandOp op = new ExpandOp();
         op.setEdgeOpt(new OpArg<>(Boolean.valueOf(true), Function.identity()));
         op.setDirection(new OpArg<>(FfiDirection.Out, Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("expand_edge_opt.json"), actual);
     }
@@ -52,7 +52,7 @@ public class ExpandOpTest {
         op.setDirection(new OpArg<>(FfiDirection.Out, Function.identity()));
         List<FfiNameOrId.ByValue> values = Arrays.asList(irCoreLib.cstrAsNameOrId("knows"));
         op.setLabels(new OpArg<List, List>(values, Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("expand_labels.json"), actual);
     }
@@ -63,7 +63,7 @@ public class ExpandOpTest {
         op.setEdgeOpt(new OpArg<>(Boolean.valueOf(true), Function.identity()));
         op.setDirection(new OpArg<>(FfiDirection.Out, Function.identity()));
         op.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("expand_alias.json"), actual);
     }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
@@ -40,7 +40,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("count.json"), irPlan.getPlanAsJson());
     }
 
@@ -51,7 +51,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("a", true));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("count_as.json"), irPlan.getPlanAsJson());
     }
 
@@ -65,7 +65,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("group.json"), irPlan.getPlanAsJson());
     }
 
@@ -80,7 +80,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("group_key.json"), irPlan.getPlanAsJson());
     }
 
@@ -95,7 +95,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("group_key_count.json"), irPlan.getPlanAsJson());
     }
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/LimitOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/LimitOpTest.java
@@ -33,7 +33,7 @@ public class LimitOpTest {
         LimitOp op = new LimitOp();
         op.setLower(new OpArg<>(Integer.valueOf(1), Function.identity()));
         op.setUpper(new OpArg<>(Integer.valueOf(2), Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("limit_range.json"), actual);
     }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/OrderOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/OrderOpTest.java
@@ -22,7 +22,7 @@ public class OrderOpTest {
     public void orderTest() throws IOException {
         OrderOp op = new OrderOp();
         op.setOrderVarWithOrder(new OpArg(Arrays.asList(Pair.with(ArgUtils.asNoneVar(), FfiOrderOpt.Asc)), Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_asc.json"), irPlan.getPlanAsJson());
     }
 
@@ -32,7 +32,7 @@ public class OrderOpTest {
         FfiProperty.ByValue property = ArgUtils.asFfiProperty("name");
         FfiVariable.ByValue var = ArgUtils.asVarPropertyOnly(property);
         op.setOrderVarWithOrder(new OpArg(Arrays.asList(Pair.with(var, FfiOrderOpt.Asc)), Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_key.json"), irPlan.getPlanAsJson());
     }
 
@@ -45,7 +45,7 @@ public class OrderOpTest {
         FfiVariable.ByValue v2 = ArgUtils.asVarPropertyOnly(p2);
         op.setOrderVarWithOrder(new OpArg(
                 Arrays.asList(Pair.with(v1, FfiOrderOpt.Asc), Pair.with(v2, FfiOrderOpt.Desc)), Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_keys.json"), irPlan.getPlanAsJson());
     }
 
@@ -55,7 +55,7 @@ public class OrderOpTest {
         FfiProperty.ByValue property = ArgUtils.asFfiProperty("~label");
         FfiVariable.ByValue var = ArgUtils.asVarPropertyOnly(property);
         op.setOrderVarWithOrder(new OpArg(Arrays.asList(Pair.with(var, FfiOrderOpt.Asc)), Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_label.json"), irPlan.getPlanAsJson());
     }
 
@@ -66,7 +66,7 @@ public class OrderOpTest {
         op.setOrderVarWithOrder(new OpArg(Arrays.asList(Pair.with(var, FfiOrderOpt.Asc)), Function.identity()));
         op.setLower(new OpArg(Integer.valueOf(1), Function.identity()));
         op.setUpper(new OpArg(Integer.valueOf(2), Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_limit.json"), irPlan.getPlanAsJson());
     }
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/PathExpandOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/PathExpandOpTest.java
@@ -1,0 +1,26 @@
+package com.alibaba.graphscope.common.intermediate.operator;
+
+import com.alibaba.graphscope.common.IrPlan;
+import com.alibaba.graphscope.common.jna.type.FfiDirection;
+import com.alibaba.graphscope.common.utils.FileUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+public class PathExpandOpTest {
+    private IrPlan irPlan = new IrPlan();
+
+    @Test
+    public void expand_1_5_Test() throws IOException {
+        PathExpandOp op = new PathExpandOp();
+        op.setEdgeOpt(new OpArg<>(Boolean.valueOf(false), Function.identity()));
+        op.setDirection(new OpArg<>(FfiDirection.Out, Function.identity()));
+        op.setLower(new OpArg(Integer.valueOf(1), Function.identity()));
+        op.setUpper(new OpArg(Integer.valueOf(5), Function.identity()));
+        irPlan.appendInterOp(-1, op);
+        String actual = irPlan.getPlanAsJson();
+        Assert.assertEquals(FileUtils.readJsonFromResource("path_expand.json"), actual);
+    }
+}

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ProjectOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ProjectOpTest.java
@@ -44,7 +44,7 @@ public class ProjectOpTest {
         List<Pair> exprWithAlias = Collections.singletonList(Pair.with(projectExpr, alias));
 
         op.setExprWithAlias(new OpArg(exprWithAlias, Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("project_tag.json"), irPlan.getPlanAsJson());
     }
 
@@ -53,7 +53,7 @@ public class ProjectOpTest {
         ScanFusionOp scanOp = new ScanFusionOp();
         scanOp.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         scanOp.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(0, scanOp);
+        irPlan.appendInterOp(-1, scanOp);
 
         ProjectOp op = new ProjectOp();
         op.setAlias(new OpArg(ArgUtils.asFfiAlias("b", true), Function.identity()));
@@ -76,7 +76,7 @@ public class ProjectOpTest {
         List<Pair> exprWithAlias = Collections.singletonList(Pair.with(projectExpr, alias));
 
         op.setExprWithAlias(new OpArg(exprWithAlias, Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("project_key.json"), irPlan.getPlanAsJson());
     }
 
@@ -85,7 +85,7 @@ public class ProjectOpTest {
         ScanFusionOp scanOp = new ScanFusionOp();
         scanOp.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         scanOp.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(0, scanOp);
+        irPlan.appendInterOp(-1, scanOp);
 
         ProjectOp op = new ProjectOp();
 
@@ -103,7 +103,7 @@ public class ProjectOpTest {
         ScanFusionOp scanOp = new ScanFusionOp();
         scanOp.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         scanOp.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(0, scanOp);
+        irPlan.appendInterOp(-1, scanOp);
 
         ProjectOp op = new ProjectOp();
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ScanFusionOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ScanFusionOpTest.java
@@ -40,7 +40,7 @@ public class ScanFusionOpTest {
     public void scanOptTest() throws IOException {
         ScanFusionOp op = new ScanFusionOp();
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_opt.json"), actual);
     }
@@ -50,7 +50,7 @@ public class ScanFusionOpTest {
         ScanFusionOp op = new ScanFusionOp();
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         op.setPredicate(new OpArg("@.id == 1", Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_expr.json"), actual);
     }
@@ -61,7 +61,7 @@ public class ScanFusionOpTest {
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         List<FfiNameOrId.ByValue> values = Arrays.asList(irCoreLib.cstrAsNameOrId("person"));
         op.setLabels(new OpArg<List, List>(values, Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_labels.json"), actual);
     }
@@ -72,7 +72,7 @@ public class ScanFusionOpTest {
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         List<FfiConst.ByValue> values = Arrays.asList(irCoreLib.int64AsConst(1L), irCoreLib.int64AsConst(2L));
         op.setIds(new OpArg<List, List>(values, Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_ids.json"), actual);
     }
@@ -82,7 +82,7 @@ public class ScanFusionOpTest {
         ScanFusionOp op = new ScanFusionOp();
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         op.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_alias.json"), actual);
     }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/SelectOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/SelectOpTest.java
@@ -32,7 +32,7 @@ public class SelectOpTest {
     public void selectOpTest() throws IOException {
         SelectOp op = new SelectOp();
         op.setPredicate(new OpArg("@.id == 1 && @.name == \"marko\"", Function.identity()));
-        irPlan.appendInterOp(0, op);
+        irPlan.appendInterOp(-1, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("select_expr.json"), actual);
     }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/PathExpandStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/PathExpandStepTest.java
@@ -1,0 +1,50 @@
+package com.alibaba.graphscope.gremlin;
+
+import com.alibaba.graphscope.common.intermediate.operator.PathExpandOp;
+import com.alibaba.graphscope.common.jna.type.FfiDirection;
+import com.alibaba.graphscope.common.jna.type.FfiNameOrId;
+import com.alibaba.graphscope.gremlin.plugin.traversal.IrCustomizedTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import com.alibaba.graphscope.gremlin.InterOpCollectionBuilder.StepTransformFactory;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+public class PathExpandStepTest {
+    private Graph graph = TinkerFactory.createModern();
+    private GraphTraversalSource g = graph.traversal(IrCustomizedTraversalSource.class);
+
+    @Test
+    public void g_V_path_expand_test() {
+        IrCustomizedTraversalSource g1 = (IrCustomizedTraversalSource) g;
+        Traversal traversal = g1.V().out(__.range(1, 2));
+        Step step = traversal.asAdmin().getEndStep();
+        PathExpandOp op = (PathExpandOp) StepTransformFactory.PATH_EXPAND_STEP.apply(step);
+
+        Assert.assertEquals(FfiDirection.Out, op.getDirection().get().applyArg());
+        Assert.assertEquals(false, op.getIsEdge().get().applyArg());
+        Assert.assertEquals(2, op.getLower().get().applyArg());
+        Assert.assertEquals(3, op.getUpper().get().applyArg());
+    }
+
+    @Test
+    public void g_V_path_expand_label_test() {
+        IrCustomizedTraversalSource g1 = (IrCustomizedTraversalSource) g;
+        Traversal traversal = g1.V().out(__.range(1, 2), "knows");
+        Step step = traversal.asAdmin().getEndStep();
+        PathExpandOp op = (PathExpandOp) StepTransformFactory.PATH_EXPAND_STEP.apply(step);
+
+        Assert.assertEquals(FfiDirection.Out, op.getDirection().get().applyArg());
+        Assert.assertEquals(false, op.getIsEdge().get().applyArg());
+        Assert.assertEquals(2, op.getLower().get().applyArg());
+        Assert.assertEquals(3, op.getUpper().get().applyArg());
+        FfiNameOrId.ByValue label = ((List<FfiNameOrId.ByValue>) op.getLabels().get().applyArg()).get(0);
+        Assert.assertEquals("knows", label.name);
+    }
+}

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/NegativeEvalTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/NegativeEvalTest.java
@@ -18,6 +18,7 @@ package com.alibaba.graphscope.gremlin.antlr4;
 
 import com.alibaba.graphscope.gremlin.exception.InvalidGremlinScriptException;
 import com.alibaba.graphscope.gremlin.plugin.script.AntlrToJavaScriptEngine;
+import com.alibaba.graphscope.gremlin.plugin.traversal.IrCustomizedTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
@@ -37,7 +38,7 @@ public class NegativeEvalTest {
     @Before
     public void before() {
         Graph graph = TinkerFactory.createModern();
-        GraphTraversalSource g = graph.traversal();
+        GraphTraversalSource g = graph.traversal(IrCustomizedTraversalSource.class);
         Bindings globalBindings = new SimpleBindings();
         globalBindings.put("g", g);
         context = new SimpleScriptContext();

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
@@ -622,17 +622,19 @@ public class PositiveEvalTest {
 
     @Test
     public void g_V_path_expand_test() {
-        Assert.assertEquals(((IrCustomizedTraversalSource) g).V().out(__.range(1, 2)), eval("g.V().out(range(1, 2))"));
+        Assert.assertEquals(((IrCustomizedTraversalSource) g).V().out(__.range(1, 2)), eval("g.V().out('1..2')"));
     }
 
     @Test
     public void g_V_path_expand_label_test() {
-        Assert.assertEquals(((IrCustomizedTraversalSource) g).V().out(__.range(1, 2), "knows"), eval("g.V().out(range(1, 2), \"knows\"))"));
+        Assert.assertEquals(((IrCustomizedTraversalSource) g).V().out(__.range(1, 2), "knows"),
+                eval("g.V().out('1..2', \"knows\"))"));
     }
 
     @Test
     public void g_V_path_expand_labels_test() {
-        Assert.assertEquals(((IrCustomizedTraversalSource) g).V().out(__.range(1, 2), "knows", "person"), eval("g.V().out(range(1, 2), \"knows\", \"person\"))"));
+        Assert.assertEquals(((IrCustomizedTraversalSource) g).V().out(__.range(1, 2), "knows", "person"),
+                eval("g.V().out(\"1..2\", \"knows\", \"person\"))"));
     }
 
     @Test

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
@@ -17,6 +17,7 @@
 package com.alibaba.graphscope.gremlin.antlr4;
 
 import com.alibaba.graphscope.gremlin.plugin.script.AntlrToJavaScriptEngine;
+import com.alibaba.graphscope.gremlin.plugin.traversal.IrCustomizedTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.Order;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
@@ -44,7 +45,7 @@ public class PositiveEvalTest {
     @Before
     public void before() {
         graph = TinkerFactory.createModern();
-        g = graph.traversal();
+        g = graph.traversal(IrCustomizedTraversalSource.class);
         Bindings globalBindings = new SimpleBindings();
         globalBindings.put("g", g);
         context = new SimpleScriptContext();
@@ -564,7 +565,7 @@ public class PositiveEvalTest {
 
     @Test
     public void g_V_groupCount_by_values_as_test() {
-        Assert.assertEquals(g.V().groupCount().by(__.values("name").as("a")), eval("g.V().groupCount().by(values(\"name\")).as(\"a\")"));
+        Assert.assertEquals(g.V().groupCount().by(__.values("name").as("a")), eval("g.V().groupCount().by(__.values(\"name\").as(\"a\"))"));
     }
 
     @Test
@@ -617,6 +618,21 @@ public class PositiveEvalTest {
     public void g_V_where_a_eq_b_nested_value_age_test() {
         Assert.assertEquals(g.V().where("a", P.eq("b")).by("age").by(__.values("age")),
                 eval("g.V().where(\"a\", P.eq(\"b\")).by(\"age\").by(__.values(\"age\"))"));
+    }
+
+    @Test
+    public void g_V_path_expand_test() {
+        Assert.assertEquals(((IrCustomizedTraversalSource) g).V().out(__.range(1, 2)), eval("g.V().out(range(1, 2))"));
+    }
+
+    @Test
+    public void g_V_path_expand_label_test() {
+        Assert.assertEquals(((IrCustomizedTraversalSource) g).V().out(__.range(1, 2), "knows"), eval("g.V().out(range(1, 2), \"knows\"))"));
+    }
+
+    @Test
+    public void g_V_path_expand_labels_test() {
+        Assert.assertEquals(((IrCustomizedTraversalSource) g).V().out(__.range(1, 2), "knows", "person"), eval("g.V().out(range(1, 2), \"knows\", \"person\"))"));
     }
 
     @Test

--- a/research/query_service/ir/compiler/src/test/resources/path_expand.json
+++ b/research/query_service/ir/compiler/src/test/resources/path_expand.json
@@ -1,0 +1,33 @@
+{
+  "nodes": [
+    {
+      "opr": {
+        "opr": {
+          "Path": {
+            "base": {
+              "v_tag": null,
+              "direction": 0,
+              "params": {
+                "table_names": [],
+                "columns": [],
+                "limit": null,
+                "predicate": null,
+                "requirements": []
+              },
+              "is_edge": false,
+              "alias": null
+            },
+            "start_tag": null,
+            "is_whole_path": false,
+            "alias": null,
+            "hop_range": {
+              "lower": 1,
+              "upper": 5
+            }
+          }
+        }
+      },
+      "children": []
+    }
+  ]
+}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. supported out('1..5', 'label') in antlr.
2. add IrCustomizedTraversal and PathExpandStep, to carry the info of the newly-created grammar nodes.
3. add transformations from PathExpandStep to PathExpandOp, then to IrPlan.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

