### PR TITLE
Where subtask

### DIFF
--- a/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
+++ b/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
@@ -74,6 +74,7 @@ traversalMethod
     | traversalMethod_inV   // inV()
     | traversalMethod_outV  // outV()
     | traversalMethod_otherV  // otherV()
+    | traversalMethod_not  // not()
     ;
 
 traversalSourceSpawnMethod_V
@@ -267,9 +268,12 @@ traversalMethod_is
 // where(P.eq("a")).by("age")
 // where("c", P.eq("a")).by("id").by("age")
 // where(out().out()...)
+// where(__.as("a")...as("b"))
+// where(__.not(__.out)) equal to not(__.out)
 traversalMethod_where
 	: 'where' LPAREN traversalPredicate RPAREN (DOT traversalMethod_whereby_list)?
 	| 'where' LPAREN stringLiteral COMMA traversalPredicate RPAREN (DOT traversalMethod_whereby_list)?
+    | 'where' LPAREN (ANON_TRAVERSAL_ROOT DOT)? traversalMethod_not RPAREN // match not(__.out) as traversalMethod_not instead of nestedTraversal
 	| 'where' LPAREN nestedTraversal RPAREN
 	;
 
@@ -280,6 +284,10 @@ traversalMethod_whereby
 
 traversalMethod_whereby_list
     : traversalMethod_whereby (DOT traversalMethod_whereby)*
+    ;
+
+traversalMethod_not
+    : 'not' LPAREN nestedTraversal RPAREN
     ;
 
 // only permit non empty, \'\' or \"\" or \'null\' is meaningless as a parameter

--- a/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
+++ b/research/query_service/ir/compiler/src/main/antlr4/GremlinGS.g4
@@ -266,9 +266,11 @@ traversalMethod_is
 // where("c", P.eq("a"))
 // where(P.eq("a")).by("age")
 // where("c", P.eq("a")).by("id").by("age")
+// where(out().out()...)
 traversalMethod_where
 	: 'where' LPAREN traversalPredicate RPAREN (DOT traversalMethod_whereby_list)?
 	| 'where' LPAREN stringLiteral COMMA traversalPredicate RPAREN (DOT traversalMethod_whereby_list)?
+	| 'where' LPAREN nestedTraversal RPAREN
 	;
 
 traversalMethod_whereby
@@ -338,6 +340,11 @@ traversalPredicate
     | traversalPredicate_without
     | traversalPredicate DOT 'and' LPAREN traversalPredicate RPAREN
     | traversalPredicate DOT 'or' LPAREN traversalPredicate RPAREN
+    ;
+
+nestedTraversal
+    : chainedTraversal
+    | ANON_TRAVERSAL_ROOT DOT chainedTraversal
     ;
 
 traversalPredicate_eq

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
@@ -18,12 +18,10 @@ package com.alibaba.graphscope.common;
 
 import com.alibaba.graphscope.common.config.Configs;
 import com.alibaba.graphscope.common.config.PegasusConfig;
-import com.alibaba.graphscope.common.exception.AppendInterOpException;
-import com.alibaba.graphscope.common.exception.BuildPhysicalException;
-import com.alibaba.graphscope.common.exception.InterOpIllegalArgException;
-import com.alibaba.graphscope.common.exception.InterOpUnsupportedException;
+import com.alibaba.graphscope.common.exception.*;
 import com.alibaba.graphscope.common.intermediate.ArgAggFn;
 import com.alibaba.graphscope.common.intermediate.ArgUtils;
+import com.alibaba.graphscope.common.intermediate.InterOpCollection;
 import com.alibaba.graphscope.common.intermediate.operator.*;
 import com.alibaba.graphscope.common.intermediate.process.SinkArg;
 import com.alibaba.graphscope.common.jna.IrCoreLibrary;
@@ -48,7 +46,6 @@ public class IrPlan implements Closeable {
     private static Logger logger = LoggerFactory.getLogger(IrPlan.class);
     private static String PLAN_JSON_FILE = "plan.json";
     private Pointer ptrPlan;
-    private IntByReference oprIdx;
 
     // call libc to transform from InterOpBase to c structure
     private enum TransformFactory implements Function<InterOpBase, Pointer> {
@@ -100,6 +97,7 @@ public class IrPlan implements Closeable {
                 }
                 // todo: add other predicates
                 // todo: add limit
+
                 Optional<OpArg> aliasOpt = baseOp.getAlias();
                 if (aliasOpt.isPresent()) {
                     FfiAlias.ByValue alias = (FfiAlias.ByValue) aliasOpt.get().applyArg();
@@ -332,12 +330,35 @@ public class IrPlan implements Closeable {
                 }
                 return ptrGetV;
             }
+        },
+        APPLY_OP {
+            @Override
+            public Pointer apply(InterOpBase baseOp) {
+                ApplyOp applyOp = (ApplyOp) baseOp;
+                Optional<OpArg> subRootOpt = applyOp.getSubRootId();
+                if (!subRootOpt.isPresent()) {
+                    throw new InterOpIllegalArgException(baseOp.getClass(), "subRootId", "not present");
+                }
+                Optional<OpArg> joinKindOpt = applyOp.getJoinKind();
+                if (!joinKindOpt.isPresent()) {
+                    throw new InterOpIllegalArgException(baseOp.getClass(), "joinKind", "not present");
+                }
+                int subRootId = (Integer) subRootOpt.get().applyArg();
+                FfiJoinKind joinKind = (FfiJoinKind) joinKindOpt.get().applyArg();
+                Pointer ptrApply = irCoreLib.initApplyOperator(subRootId, joinKind);
+
+                // set alias
+                Optional<OpArg> aliasOpt = baseOp.getAlias();
+                if (aliasOpt.isPresent()) {
+                    throw new InterOpIllegalArgException(baseOp.getClass(), "subOpCollection", "the query given alias is unsupported");
+                }
+                return ptrApply;
+            }
         }
     }
 
     public IrPlan() {
         this.ptrPlan = irCoreLib.initLogicalPlan(true);
-        this.oprIdx = new IntByReference(0);
     }
 
     @Override
@@ -363,39 +384,69 @@ public class IrPlan implements Closeable {
         return json;
     }
 
-    public void appendInterOp(InterOpBase base) throws
+    // return id of the first operator
+    public int appendInterOpCollection(InterOpCollection opCollection) {
+        int rootId = 0;
+        // parent of the first op is always 0
+        IntByReference oprId = new IntByReference(0);
+        List<InterOpBase> opList = opCollection.unmodifiableCollection();
+        for (int i = 0; i < opList.size(); ++i) {
+            InterOpBase op = opList.get(i);
+            oprId = appendInterOp(oprId.getValue(), op);
+            if (i == 0) {
+                rootId = oprId.getValue();
+            }
+        }
+        return rootId;
+    }
+
+    // return id of the current operator
+    public IntByReference appendInterOp(int parentId, InterOpBase base) throws
             InterOpIllegalArgException, InterOpUnsupportedException, AppendInterOpException {
         ResultCode resultCode;
+        IntByReference oprId = new IntByReference(parentId);
         if (base instanceof ScanFusionOp) {
             Pointer ptrScan = TransformFactory.SCAN_FUSION_OP.apply(base);
-            resultCode = irCoreLib.appendScanOperator(ptrPlan, ptrScan, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendScanOperator(ptrPlan, ptrScan, oprId.getValue(), oprId);
         } else if (base instanceof SelectOp) {
             Pointer ptrSelect = TransformFactory.SELECT_OP.apply(base);
-            resultCode = irCoreLib.appendSelectOperator(ptrPlan, ptrSelect, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendSelectOperator(ptrPlan, ptrSelect, oprId.getValue(), oprId);
         } else if (base instanceof ExpandOp) {
             Pointer ptrExpand = TransformFactory.EXPAND_OP.apply(base);
-            resultCode = irCoreLib.appendEdgexpdOperator(ptrPlan, ptrExpand, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendEdgexpdOperator(ptrPlan, ptrExpand, oprId.getValue(), oprId);
         } else if (base instanceof LimitOp) {
             Pointer ptrLimit = TransformFactory.LIMIT_OP.apply(base);
-            resultCode = irCoreLib.appendLimitOperator(ptrPlan, ptrLimit, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendLimitOperator(ptrPlan, ptrLimit, oprId.getValue(), oprId);
         } else if (base instanceof ProjectOp) {
             Pointer ptrProject = TransformFactory.PROJECT_OP.apply(base);
-            resultCode = irCoreLib.appendProjectOperator(ptrPlan, ptrProject, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendProjectOperator(ptrPlan, ptrProject, oprId.getValue(), oprId);
         } else if (base instanceof OrderOp) {
             Pointer ptrOrder = TransformFactory.ORDER_OP.apply(base);
-            resultCode = irCoreLib.appendOrderbyOperator(ptrPlan, ptrOrder, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendOrderbyOperator(ptrPlan, ptrOrder, oprId.getValue(), oprId);
         } else if (base instanceof GroupOp) {
             Pointer ptrGroup = TransformFactory.GROUP_OP.apply(base);
-            resultCode = irCoreLib.appendGroupbyOperator(ptrPlan, ptrGroup, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendGroupbyOperator(ptrPlan, ptrGroup, oprId.getValue(), oprId);
         } else if (base instanceof DedupOp) {
             Pointer ptrDedup = TransformFactory.DEDUP_OP.apply(base);
-            resultCode = irCoreLib.appendDedupOperator(ptrPlan, ptrDedup, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendDedupOperator(ptrPlan, ptrDedup, oprId.getValue(), oprId);
         } else if (base instanceof SinkOp) {
             Pointer ptrSink = TransformFactory.SINK_OP.apply(base);
-            resultCode = irCoreLib.appendSinkOperator(ptrPlan, ptrSink, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendSinkOperator(ptrPlan, ptrSink, oprId.getValue(), oprId);
         } else if (base instanceof GetVOp) {
             Pointer ptrGetV = TransformFactory.GETV_OP.apply(base);
-            resultCode = irCoreLib.appendGetvOperator(ptrPlan, ptrGetV, oprIdx.getValue(), oprIdx);
+            resultCode = irCoreLib.appendGetvOperator(ptrPlan, ptrGetV, oprId.getValue(), oprId);
+        } else if (base instanceof ApplyOp) {
+            ApplyOp applyOp = (ApplyOp) base;
+            Optional<OpArg> subOps = applyOp.getSubOpCollection();
+            if (!subOps.isPresent()) {
+                throw new InterOpIllegalArgException(base.getClass(), "subOpCollection", "is not present in apply");
+            }
+            InterOpCollection opCollection = (InterOpCollection) subOps.get().applyArg();
+            int subRootId = appendInterOpCollection(opCollection);
+            applyOp.setSubRootId(new OpArg(Integer.valueOf(subRootId), Function.identity()));
+
+            Pointer ptrApply = TransformFactory.APPLY_OP.apply(base);
+            resultCode = irCoreLib.appendApplyOperator(ptrPlan, ptrApply, oprId.getValue(), oprId);
         } else {
             throw new InterOpUnsupportedException(base.getClass(), "unimplemented yet");
         }
@@ -403,12 +454,13 @@ public class IrPlan implements Closeable {
             throw new AppendInterOpException(base.getClass(), resultCode);
         }
         // add alias after the op if necessary
-        setPostAlias(base);
+        return setPostAlias(oprId.getValue(), base);
     }
 
-    private void setPostAlias(InterOpBase base) {
+    private IntByReference setPostAlias(int parentId, InterOpBase base) {
+        IntByReference oprId = new IntByReference(parentId);
         if (!(base instanceof ScanFusionOp || base instanceof ExpandOp
-                || base instanceof ProjectOp || base instanceof GroupOp || base instanceof GetVOp)
+                || base instanceof ProjectOp || base instanceof GroupOp || base instanceof ApplyOp || base instanceof GetVOp)
                 && base.getAlias().isPresent()) {
             FfiAlias.ByValue ffiAlias = (FfiAlias.ByValue) base.getAlias().get().applyArg();
             Pointer ptrAs = irCoreLib.initAsOperator();
@@ -416,11 +468,12 @@ public class IrPlan implements Closeable {
             if (asResult != null && asResult != ResultCode.Success) {
                 throw new AppendInterOpException(base.getClass(), asResult);
             }
-            ResultCode appendResult = irCoreLib.appendAsOperator(ptrPlan, ptrAs, oprIdx.getValue(), oprIdx);
+            ResultCode appendResult = irCoreLib.appendAsOperator(ptrPlan, ptrAs, parentId, oprId);
             if (appendResult != null && appendResult != ResultCode.Success) {
                 throw new AppendInterOpException(base.getClass(), appendResult);
             }
         }
+        return oprId;
     }
 
     public byte[] toPhysicalBytes(Configs configs) throws BuildPhysicalException {

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/IrPlan.java
@@ -387,8 +387,8 @@ public class IrPlan implements Closeable {
     // return id of the first operator
     public int appendInterOpCollection(InterOpCollection opCollection) {
         int rootId = 0;
-        // parent of the first op is always 0
-        IntByReference oprId = new IntByReference(0);
+        // parent of the first op is always -1
+        IntByReference oprId = new IntByReference(-1);
         List<InterOpBase> opList = opCollection.unmodifiableCollection();
         for (int i = 0; i < opList.size(); ++i) {
             InterOpBase op = opList.get(i);

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/ApplyOp.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/operator/ApplyOp.java
@@ -1,0 +1,45 @@
+package com.alibaba.graphscope.common.intermediate.operator;
+
+import java.util.Optional;
+
+public class ApplyOp extends InterOpBase {
+    // InterOpCollection
+    private Optional<OpArg> subOpCollection;
+
+    // Integer
+    private Optional<OpArg> subRootId;
+
+    // FfiJoinKind
+    private Optional<OpArg> joinKind;
+
+    public ApplyOp() {
+        super();
+        subOpCollection = Optional.empty();
+        subRootId = Optional.empty();
+        joinKind = Optional.empty();
+    }
+
+    public Optional<OpArg> getSubOpCollection() {
+        return subOpCollection;
+    }
+
+    public Optional<OpArg> getSubRootId() {
+        return subRootId;
+    }
+
+    public Optional<OpArg> getJoinKind() {
+        return joinKind;
+    }
+
+    public void setSubOpCollection(OpArg subOpCollection) {
+        this.subOpCollection = Optional.of(subOpCollection);
+    }
+
+    public void setSubRootId(OpArg subRootId) {
+        this.subRootId = Optional.of(subRootId);
+    }
+
+    public void setJoinKind(OpArg joinKind) {
+        this.joinKind = Optional.of(joinKind);
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/process/SinkOutputProcessor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/process/SinkOutputProcessor.java
@@ -69,8 +69,8 @@ public class SinkOutputProcessor implements InterOpProcessor {
             } else if (cur instanceof ApplyOp) {
                 ApplyOp applyOp = (ApplyOp) cur;
                 FfiJoinKind joinKind = (FfiJoinKind) applyOp.getJoinKind().get().applyArg();
-                // where
-                if (joinKind == FfiJoinKind.Semi) {
+                // where or not
+                if (joinKind == FfiJoinKind.Semi || joinKind == FfiJoinKind.Anti) {
                     continue;
                 } else {
                     throw new InterOpUnsupportedException(cur.getClass(), "join kind is unsupported yet");

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/process/SinkOutputProcessor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/intermediate/process/SinkOutputProcessor.java
@@ -21,6 +21,7 @@ import com.alibaba.graphscope.common.intermediate.ArgAggFn;
 import com.alibaba.graphscope.common.intermediate.InterOpCollection;
 import com.alibaba.graphscope.common.intermediate.operator.*;
 import com.alibaba.graphscope.common.jna.type.FfiAlias;
+import com.alibaba.graphscope.common.jna.type.FfiJoinKind;
 import org.javatuples.Pair;
 
 import java.util.List;
@@ -65,6 +66,15 @@ public class SinkOutputProcessor implements InterOpProcessor {
                     sinkArg.addColumnName(aggFn.getAlias().alias);
                 }
                 break;
+            } else if (cur instanceof ApplyOp) {
+                ApplyOp applyOp = (ApplyOp) cur;
+                FfiJoinKind joinKind = (FfiJoinKind) applyOp.getJoinKind().get().applyArg();
+                // where
+                if (joinKind == FfiJoinKind.Semi) {
+                    continue;
+                } else {
+                    throw new InterOpUnsupportedException(cur.getClass(), "join kind is unsupported yet");
+                }
             } else {
                 throw new InterOpUnsupportedException(cur.getClass(), "unimplemented yet");
             }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/IrCoreLibrary.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/IrCoreLibrary.java
@@ -124,6 +124,12 @@ public interface IrCoreLibrary extends Library {
 
     ResultCode appendGetvOperator(Pointer plan, Pointer getV, int parent, IntByReference oprIdx);
 
+    Pointer initApplyOperator(int subtaskRoot, FfiJoinKind joinKind);
+
+    ResultCode setApplyAlias(Pointer apply, FfiAlias.ByValue alias);
+
+    ResultCode appendApplyOperator(Pointer plan, Pointer apply, int parent, IntByReference oprIdx);
+
     FfiNameOrId.ByValue noneNameOrId();
 
     FfiNameOrId.ByValue cstrAsNameOrId(String name);

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiJoinKind.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/common/jna/type/FfiJoinKind.java
@@ -1,0 +1,34 @@
+package com.alibaba.graphscope.common.jna.type;
+
+import com.alibaba.graphscope.common.jna.IntEnum;
+
+public enum FfiJoinKind implements IntEnum<FfiJoinKind> {
+    /// Inner join
+    Inner,
+    /// Left outer join
+    LeftOuter,
+    /// Right outer join
+    RightOuter,
+    /// Full outer join
+    FullOuter,
+    /// Left semi-join, right alternative can be naturally adapted
+    Semi,
+    /// Left anti-join, right alternative can be naturally adapted
+    Anti,
+    /// aka. Cartesian product
+    Times;
+
+    @Override
+    public int getInt() {
+        return this.ordinal();
+    }
+
+    @Override
+    public FfiJoinKind getEnum(int i) {
+        FfiJoinKind opts[] = values();
+        if (i < opts.length && i >= 0) {
+            return opts[i];
+        }
+        return null;
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
@@ -381,6 +381,8 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
                     TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
         } else if (ctx.traversalPredicate() != null) {
             graphTraversal.where(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        } else if (ctx.traversalMethod_not() != null) {
+            visitTraversalMethod_not(ctx.traversalMethod_not());
         } else if (ctx.nestedTraversal() != null) {
             Traversal whereTraversal = visitNestedTraversal(ctx.nestedTraversal());
             graphTraversal.where(whereTraversal);
@@ -407,5 +409,15 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
             }
         }
         return graphTraversal;
+    }
+
+    @Override
+    public Traversal visitTraversalMethod_not(GremlinGSParser.TraversalMethod_notContext ctx) {
+        if (ctx.nestedTraversal() != null) {
+            Traversal whereTraversal = visitNestedTraversal(ctx.nestedTraversal());
+            return graphTraversal.not(whereTraversal);
+        } else {
+            throw new UnsupportedEvalException(ctx.getClass(), "supported pattern is [not(..out()..)]");
+        }
     }
 }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalMethodVisitor.java
@@ -26,6 +26,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.step.ByModulating;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderGlobalStep;
 
 public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal> {
@@ -380,8 +381,12 @@ public class TraversalMethodVisitor extends TraversalRootVisitor<GraphTraversal>
                     TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
         } else if (ctx.traversalPredicate() != null) {
             graphTraversal.where(TraversalPredicateVisitor.getInstance().visitTraversalPredicate(ctx.traversalPredicate()));
+        } else if (ctx.nestedTraversal() != null) {
+            Traversal whereTraversal = visitNestedTraversal(ctx.nestedTraversal());
+            graphTraversal.where(whereTraversal);
         } else {
-            throw new UnsupportedEvalException(ctx.getClass(), "supported pattern is [where(P.eq(...))] or [where(a, P.eq(...))]");
+            throw new UnsupportedEvalException(ctx.getClass(),
+                    "supported pattern is [where(P.eq(...))] or [where(a, P.eq(...))] or [where(sub_traversal)]");
         }
         if (ctx.traversalMethod_whereby_list() != null) {
             ByModulating byModulating = (ByModulating) graphTraversal.asAdmin().getEndStep();

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalRootVisitor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/antlr4/TraversalRootVisitor.java
@@ -66,4 +66,10 @@ public class TraversalRootVisitor<G extends Traversal> extends GremlinGSBaseVisi
             return visit(ctx.getChild(2));
         }
     }
+
+    @Override
+    public Traversal visitNestedTraversal(final GremlinGSParser.NestedTraversalContext ctx) {
+        TraversalMethodVisitor nestedTraversal = new TraversalMethodVisitor(gvisitor, GremlinAntlrToJava.getTraversalSupplier().get());
+        return nestedTraversal.visitChainedTraversal(ctx.chainedTraversal());
+    }
 }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
@@ -29,7 +29,8 @@ public class GremlinResultAnalyzer {
             } else if (Utils.equalClass(step, HasStep.class) || Utils.equalClass(step, DedupGlobalStep.class)
                     || Utils.equalClass(step, RangeGlobalStep.class) || Utils.equalClass(step, OrderGlobalStep.class)
                     || Utils.equalClass(step, IsStep.class) || Utils.equalClass(step, WherePredicateStep.class)
-                    || Utils.equalClass(step, TraversalFilterStep.class) || Utils.equalClass(step, WhereTraversalStep.class)) {
+                    || Utils.equalClass(step, TraversalFilterStep.class) || Utils.equalClass(step, WhereTraversalStep.class)
+                    || Utils.equalClass(step, NotStep.class)) {
                 // do nothing;
             } else {
                 throw new UnsupportedStepException(step.getClass(), "unimplemented yet");

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
@@ -29,7 +29,7 @@ public class GremlinResultAnalyzer {
             } else if (Utils.equalClass(step, HasStep.class) || Utils.equalClass(step, DedupGlobalStep.class)
                     || Utils.equalClass(step, RangeGlobalStep.class) || Utils.equalClass(step, OrderGlobalStep.class)
                     || Utils.equalClass(step, IsStep.class) || Utils.equalClass(step, WherePredicateStep.class)
-                    || Utils.equalClass(step, TraversalFilterStep.class)) {
+                    || Utils.equalClass(step, TraversalFilterStep.class) || Utils.equalClass(step, WhereTraversalStep.class)) {
                 // do nothing;
             } else {
                 throw new UnsupportedStepException(step.getClass(), "unimplemented yet");

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
@@ -28,7 +28,8 @@ public class GremlinResultAnalyzer {
                 parserType = GremlinResultParserFactory.GROUP;
             } else if (Utils.equalClass(step, HasStep.class) || Utils.equalClass(step, DedupGlobalStep.class)
                     || Utils.equalClass(step, RangeGlobalStep.class) || Utils.equalClass(step, OrderGlobalStep.class)
-                    || Utils.equalClass(step, IsStep.class) || Utils.equalClass(step, WherePredicateStep.class)) {
+                    || Utils.equalClass(step, IsStep.class) || Utils.equalClass(step, WherePredicateStep.class)
+                    || Utils.equalClass(step, TraversalFilterStep.class)) {
                 // do nothing;
             } else {
                 throw new UnsupportedStepException(step.getClass(), "unimplemented yet");

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/OpArgTransformFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/OpArgTransformFactory.java
@@ -19,11 +19,13 @@ package com.alibaba.graphscope.gremlin.transform;
 import com.alibaba.graphscope.common.exception.OpArgIllegalException;
 import com.alibaba.graphscope.common.intermediate.ArgAggFn;
 import com.alibaba.graphscope.common.intermediate.ArgUtils;
+import com.alibaba.graphscope.common.intermediate.InterOpCollection;
 import com.alibaba.graphscope.common.jna.type.*;
 import com.alibaba.graphscope.common.jna.type.FfiDirection;
 import com.alibaba.graphscope.common.jna.type.FfiNameOrId;
 import com.alibaba.graphscope.common.jna.type.FfiScanOpt;
 import com.alibaba.graphscope.gremlin.Utils;
+import com.alibaba.graphscope.gremlin.InterOpCollectionBuilder;
 import org.apache.tinkerpop.gremlin.process.traversal.*;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.IdentityTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ValueTraversal;
@@ -107,7 +109,7 @@ public class OpArgTransformFactory {
             PROJECT_EXPR_FROM_BY_TRAVERSALS = (Map<String, Traversal.Admin> map) -> {
         List<Pair<String, FfiAlias.ByValue>> projectWithAliasList = new ArrayList<>();
         map.forEach((k, v) -> {
-            String expression = ByTraversalTransformFactory.getTagByTraversalAsExpr(k, v);
+            String expression = ProjectTraversalTransformFactory.getTagProjectTraversalAsExpr(k, v);
             String formatAlias = formatProjectAlias(expression);
             projectWithAliasList.add(Pair.with(expression, ArgUtils.asFfiAlias(formatAlias, false)));
         });
@@ -186,11 +188,11 @@ public class OpArgTransformFactory {
             // order().by(select("a"))
             // order().by(select("a").by(values(...)))
             // order().by(select("a").values(...))
-            if (ByTraversalTransformFactory.isTagPropertyPattern(admin)) {
-                Pair<String, Traversal.Admin> tagProperty = ByTraversalTransformFactory.getByTraversalAsTagProperty(admin);
-                orderKey = ByTraversalTransformFactory.getTagByTraversalAsVar(tagProperty.getValue0(), tagProperty.getValue1());
+            if (ProjectTraversalTransformFactory.isTagPropertyPattern(admin)) {
+                Pair<String, Traversal.Admin> tagProperty = ProjectTraversalTransformFactory.getProjectTraversalAsTagProperty(admin);
+                orderKey = ProjectTraversalTransformFactory.getTagProjectTraversalAsVar(tagProperty.getValue0(), tagProperty.getValue1());
             } else { // order().by("name"), order().by(values("name"))
-                orderKey = ByTraversalTransformFactory.getTagByTraversalAsVar("", admin);
+                orderKey = ProjectTraversalTransformFactory.getTagProjectTraversalAsVar("", admin);
             }
             vars.add(Pair.with(orderKey, orderOpt));
         });
@@ -350,4 +352,7 @@ public class OpArgTransformFactory {
             throw new OpArgIllegalException(OpArgIllegalException.Cause.INVALID_TYPE, "cannot get FfiVOpt from " + step.getClass());
         }
     };
+
+    public static Function<Traversal.Admin, InterOpCollection>
+            INTER_OPS_FROM_SUB_TRAVERSAL = (Traversal.Admin sub) -> (new InterOpCollectionBuilder(sub)).build();
 }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransform.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransform.java
@@ -82,7 +82,7 @@ public interface PredicateExprTransform extends Function {
         return expr;
     }
 
-    default String getpredicateValue(Object value) {
+    default String getPredicateValue(Object value) {
         String predicateValue;
         if (value instanceof String) {
             predicateValue = String.format("\"%s\"", value);
@@ -98,7 +98,7 @@ public interface PredicateExprTransform extends Function {
                     throw new OpArgIllegalException(OpArgIllegalException.Cause.UNSUPPORTED_TYPE,
                             "nested list of predicate value is unsupported");
                 }
-                content += getpredicateValue(v);
+                content += getPredicateValue(v);
             }
             predicateValue = String.format("[%s]", content);
         } else {
@@ -122,7 +122,7 @@ public interface PredicateExprTransform extends Function {
         if (value instanceof PredicateExprTransformFactory.WherePredicateValue) {
             valueKeyExist = getExprIfPropertyExist(value.toString());
         }
-        String predicateExpr = String.format("%s %s %s", subject, predicate, getpredicateValue(value));
+        String predicateExpr = String.format("%s %s %s", subject, predicate, getPredicateValue(value));
         StringBuilder builder = new StringBuilder(predicateExpr);
         if (!valueKeyExist.isEmpty()) {
             builder.insert(0, String.format("%s && ", valueKeyExist));

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransformFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransformFactory.java
@@ -66,7 +66,7 @@ public enum PredicateExprTransformFactory implements PredicateExprTransform {
             TraversalRing traversalRing = Utils.getFieldValue(WherePredicateStep.class, step, "traversalRing");
 
             String startTag = startKey.isPresent() ? startKey.get() : "";
-            String startBy = ByTraversalTransformFactory.getTagByTraversalAsExpr(startTag, traversalRing.next());
+            String startBy = ProjectTraversalTransformFactory.getTagProjectTraversalAsExpr(startTag, traversalRing.next());
 
             P predicate = (P) step.getPredicate().get();
             List<String> selectKeys = Utils.getFieldValue(WherePredicateStep.class, step, "selectKeys");
@@ -81,7 +81,7 @@ public enum PredicateExprTransformFactory implements PredicateExprTransform {
                     traverseAndUpdateP((P) p1, selectKeysIterator, traversalRing);
                 });
             } else {
-                String tagProperty = ByTraversalTransformFactory.getTagByTraversalAsExpr(selectKeysIterator.next(), traversalRing.next());
+                String tagProperty = ProjectTraversalTransformFactory.getTagProjectTraversalAsExpr(selectKeysIterator.next(), traversalRing.next());
                 predicate.setValue(new WherePredicateValue(tagProperty));
             }
         }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransformFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/PredicateExprTransformFactory.java
@@ -19,6 +19,7 @@ import com.alibaba.graphscope.gremlin.Utils;
 import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.IsStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WherePredicateStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
 import org.apache.tinkerpop.gremlin.process.traversal.util.ConnectiveP;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalRing;
@@ -84,6 +85,15 @@ public enum PredicateExprTransformFactory implements PredicateExprTransform {
                 String tagProperty = ProjectTraversalTransformFactory.getTagProjectTraversalAsExpr(selectKeysIterator.next(), traversalRing.next());
                 predicate.setValue(new WherePredicateValue(tagProperty));
             }
+        }
+    },
+    EXPR_FROM_WHERE_END {
+        @Override
+        public String apply(Object arg) {
+            WhereTraversalStep.WhereEndStep endStep = (WhereTraversalStep.WhereEndStep) arg;
+            String matchTag = endStep.getScopeKeys().iterator().next();
+            P predicate = P.eq(new WherePredicateValue("@" + matchTag));
+            return flatPredicate("@", predicate);
         }
     };
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/DedupOpTest.java
@@ -37,7 +37,7 @@ public class DedupOpTest {
         FfiVariable.ByValue dedupKey = ArgUtils.asNoneVar();
         op.setDedupKeys(new OpArg(Collections.singletonList(dedupKey), Function.identity()));
 
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("dedup.json"), irPlan.getPlanAsJson());
     }
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ExpandOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ExpandOpTest.java
@@ -40,7 +40,7 @@ public class ExpandOpTest {
         ExpandOp op = new ExpandOp();
         op.setEdgeOpt(new OpArg<>(Boolean.valueOf(true), Function.identity()));
         op.setDirection(new OpArg<>(FfiDirection.Out, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("expand_edge_opt.json"), actual);
     }
@@ -52,7 +52,7 @@ public class ExpandOpTest {
         op.setDirection(new OpArg<>(FfiDirection.Out, Function.identity()));
         List<FfiNameOrId.ByValue> values = Arrays.asList(irCoreLib.cstrAsNameOrId("knows"));
         op.setLabels(new OpArg<List, List>(values, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("expand_labels.json"), actual);
     }
@@ -63,7 +63,7 @@ public class ExpandOpTest {
         op.setEdgeOpt(new OpArg<>(Boolean.valueOf(true), Function.identity()));
         op.setDirection(new OpArg<>(FfiDirection.Out, Function.identity()));
         op.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("expand_alias.json"), actual);
     }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/GroupOpTest.java
@@ -40,7 +40,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("count.json"), irPlan.getPlanAsJson());
     }
 
@@ -51,7 +51,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("a", true));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("count_as.json"), irPlan.getPlanAsJson());
     }
 
@@ -65,7 +65,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("group.json"), irPlan.getPlanAsJson());
     }
 
@@ -80,7 +80,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.ToList, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("group_key.json"), irPlan.getPlanAsJson());
     }
 
@@ -95,7 +95,7 @@ public class GroupOpTest {
         ArgAggFn aggFn = new ArgAggFn(FfiAggOpt.Count, ArgUtils.asFfiAlias("values", false));
         op.setGroupByValues(new OpArg(Collections.singletonList(aggFn), Function.identity()));
 
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("group_key_count.json"), irPlan.getPlanAsJson());
     }
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/LimitOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/LimitOpTest.java
@@ -33,7 +33,7 @@ public class LimitOpTest {
         LimitOp op = new LimitOp();
         op.setLower(new OpArg<>(Integer.valueOf(1), Function.identity()));
         op.setUpper(new OpArg<>(Integer.valueOf(2), Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("limit_range.json"), actual);
     }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/OrderOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/OrderOpTest.java
@@ -22,7 +22,7 @@ public class OrderOpTest {
     public void orderTest() throws IOException {
         OrderOp op = new OrderOp();
         op.setOrderVarWithOrder(new OpArg(Arrays.asList(Pair.with(ArgUtils.asNoneVar(), FfiOrderOpt.Asc)), Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_asc.json"), irPlan.getPlanAsJson());
     }
 
@@ -32,7 +32,7 @@ public class OrderOpTest {
         FfiProperty.ByValue property = ArgUtils.asFfiProperty("name");
         FfiVariable.ByValue var = ArgUtils.asVarPropertyOnly(property);
         op.setOrderVarWithOrder(new OpArg(Arrays.asList(Pair.with(var, FfiOrderOpt.Asc)), Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_key.json"), irPlan.getPlanAsJson());
     }
 
@@ -45,7 +45,7 @@ public class OrderOpTest {
         FfiVariable.ByValue v2 = ArgUtils.asVarPropertyOnly(p2);
         op.setOrderVarWithOrder(new OpArg(
                 Arrays.asList(Pair.with(v1, FfiOrderOpt.Asc), Pair.with(v2, FfiOrderOpt.Desc)), Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_keys.json"), irPlan.getPlanAsJson());
     }
 
@@ -55,7 +55,7 @@ public class OrderOpTest {
         FfiProperty.ByValue property = ArgUtils.asFfiProperty("~label");
         FfiVariable.ByValue var = ArgUtils.asVarPropertyOnly(property);
         op.setOrderVarWithOrder(new OpArg(Arrays.asList(Pair.with(var, FfiOrderOpt.Asc)), Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_label.json"), irPlan.getPlanAsJson());
     }
 
@@ -66,7 +66,7 @@ public class OrderOpTest {
         op.setOrderVarWithOrder(new OpArg(Arrays.asList(Pair.with(var, FfiOrderOpt.Asc)), Function.identity()));
         op.setLower(new OpArg(Integer.valueOf(1), Function.identity()));
         op.setUpper(new OpArg(Integer.valueOf(2), Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("order_limit.json"), irPlan.getPlanAsJson());
     }
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ProjectOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ProjectOpTest.java
@@ -44,7 +44,7 @@ public class ProjectOpTest {
         List<Pair> exprWithAlias = Collections.singletonList(Pair.with(projectExpr, alias));
 
         op.setExprWithAlias(new OpArg(exprWithAlias, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("project_tag.json"), irPlan.getPlanAsJson());
     }
 
@@ -53,7 +53,7 @@ public class ProjectOpTest {
         ScanFusionOp scanOp = new ScanFusionOp();
         scanOp.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         scanOp.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(scanOp);
+        irPlan.appendInterOp(0, scanOp);
 
         ProjectOp op = new ProjectOp();
         op.setAlias(new OpArg(ArgUtils.asFfiAlias("b", true), Function.identity()));
@@ -63,7 +63,7 @@ public class ProjectOpTest {
         List<Pair> exprWithAlias = Arrays.asList(Pair.with(projectExpr, alias));
 
         op.setExprWithAlias(new OpArg(exprWithAlias, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("project_as.json"), irPlan.getPlanAsJson());
     }
 
@@ -76,7 +76,7 @@ public class ProjectOpTest {
         List<Pair> exprWithAlias = Collections.singletonList(Pair.with(projectExpr, alias));
 
         op.setExprWithAlias(new OpArg(exprWithAlias, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("project_key.json"), irPlan.getPlanAsJson());
     }
 
@@ -85,7 +85,7 @@ public class ProjectOpTest {
         ScanFusionOp scanOp = new ScanFusionOp();
         scanOp.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         scanOp.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(scanOp);
+        irPlan.appendInterOp(0, scanOp);
 
         ProjectOp op = new ProjectOp();
 
@@ -94,7 +94,7 @@ public class ProjectOpTest {
         List<Pair> exprWithAlias = Collections.singletonList(Pair.with(projectExpr, alias));
 
         op.setExprWithAlias(new OpArg(exprWithAlias, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("project_tag_key.json"), irPlan.getPlanAsJson());
     }
 
@@ -103,7 +103,7 @@ public class ProjectOpTest {
         ScanFusionOp scanOp = new ScanFusionOp();
         scanOp.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         scanOp.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(scanOp);
+        irPlan.appendInterOp(0, scanOp);
 
         ProjectOp op = new ProjectOp();
 
@@ -112,7 +112,7 @@ public class ProjectOpTest {
         List<Pair> exprWithAlias = Collections.singletonList(Pair.with(projectExpr, alias));
 
         op.setExprWithAlias(new OpArg(exprWithAlias, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         Assert.assertEquals(FileUtils.readJsonFromResource("project_tag_keys.json"), irPlan.getPlanAsJson());
     }
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ScanFusionOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/ScanFusionOpTest.java
@@ -40,7 +40,7 @@ public class ScanFusionOpTest {
     public void scanOptTest() throws IOException {
         ScanFusionOp op = new ScanFusionOp();
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_opt.json"), actual);
     }
@@ -50,7 +50,7 @@ public class ScanFusionOpTest {
         ScanFusionOp op = new ScanFusionOp();
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         op.setPredicate(new OpArg("@.id == 1", Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_expr.json"), actual);
     }
@@ -61,7 +61,7 @@ public class ScanFusionOpTest {
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         List<FfiNameOrId.ByValue> values = Arrays.asList(irCoreLib.cstrAsNameOrId("person"));
         op.setLabels(new OpArg<List, List>(values, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_labels.json"), actual);
     }
@@ -72,7 +72,7 @@ public class ScanFusionOpTest {
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         List<FfiConst.ByValue> values = Arrays.asList(irCoreLib.int64AsConst(1L), irCoreLib.int64AsConst(2L));
         op.setIds(new OpArg<List, List>(values, Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_ids.json"), actual);
     }
@@ -82,7 +82,7 @@ public class ScanFusionOpTest {
         ScanFusionOp op = new ScanFusionOp();
         op.setScanOpt(new OpArg<>(FfiScanOpt.Entity, Function.identity()));
         op.setAlias(new OpArg(ArgUtils.asFfiAlias("a", true), Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("scan_alias.json"), actual);
     }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/SelectOpTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/common/intermediate/operator/SelectOpTest.java
@@ -32,7 +32,7 @@ public class SelectOpTest {
     public void selectOpTest() throws IOException {
         SelectOp op = new SelectOp();
         op.setPredicate(new OpArg("@.id == 1 && @.name == \"marko\"", Function.identity()));
-        irPlan.appendInterOp(op);
+        irPlan.appendInterOp(0, op);
         String actual = irPlan.getPlanAsJson();
         Assert.assertEquals(FileUtils.readJsonFromResource("select_expr.json"), actual);
     }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/WherePredicateTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/WherePredicateTest.java
@@ -8,6 +8,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.NotStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.TraversalFilterStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WherePredicateStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTraversalStep;
@@ -124,5 +125,23 @@ public class WherePredicateTest {
         Assert.assertEquals(FfiJoinKind.Semi, applyOp.getJoinKind().get().applyArg());
         InterOpCollection subOps = (InterOpCollection) applyOp.getSubOpCollection().get().applyArg();
         Assert.assertEquals(3, subOps.unmodifiableCollection().size());
+    }
+
+    @Test
+    public void g_V_not_values() {
+        Traversal traversal = g.V().not(__.values("name"));
+        NotStep step = (NotStep) traversal.asAdmin().getEndStep();
+        SelectOp selectOp = (SelectOp) StepTransformFactory.WHERE_TRAVERSAL_STEP.apply(step);
+        Assert.assertEquals("!@.name", selectOp.getPredicate().get().applyArg());
+    }
+
+    @Test
+    public void g_V_not_out_out() {
+        Traversal traversal = g.V().not(__.out().out());
+        NotStep step = (NotStep) traversal.asAdmin().getEndStep();
+        ApplyOp applyOp = (ApplyOp) StepTransformFactory.WHERE_TRAVERSAL_STEP.apply(step);
+        Assert.assertEquals(FfiJoinKind.Anti, applyOp.getJoinKind().get().applyArg());
+        InterOpCollection subOps = (InterOpCollection) applyOp.getSubOpCollection().get().applyArg();
+        Assert.assertEquals(2, subOps.unmodifiableCollection().size());
     }
 }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
@@ -632,4 +632,21 @@ public class PositiveEvalTest {
     public void g_V_outE_as_outV_test() {
         Assert.assertEquals(g.V().outE().as("a").outV(), eval("g.V().outE().as(\"a\").outV()"));
     }
+
+    @Test
+    public void g_V_where_out_out() {
+        Assert.assertEquals(g.V().where(__.out().out()), eval("g.V().where(__.out().out())"));
+    }
+
+    @Test
+    public void g_V_where_as_out() {
+        Assert.assertEquals(g.V().as("a").where(__.as("a").out().out()),
+                eval("g.V().as(\"a\").where(__.as(\"a\").out().out())"));
+    }
+
+    @Test
+    public void g_V_where_out_as() {
+        Assert.assertEquals(g.V().as("a").where(__.out().out().as("a")),
+                eval("g.V().as(\"a\").where(__.out().out().as(\"a\"))"));
+    }
 }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/antlr4/PositiveEvalTest.java
@@ -22,6 +22,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.P;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.NotStep;
 import org.apache.tinkerpop.gremlin.structure.Graph;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 import org.junit.Assert;
@@ -648,5 +649,21 @@ public class PositiveEvalTest {
     public void g_V_where_out_as() {
         Assert.assertEquals(g.V().as("a").where(__.out().out().as("a")),
                 eval("g.V().as(\"a\").where(__.out().out().as(\"a\"))"));
+    }
+
+    @Test
+    public void g_V_where_not() {
+        Traversal.Admin traversal = (Traversal.Admin) eval("g.V().where(__.not(__.out()))");
+        Assert.assertEquals(NotStep.class, traversal.getEndStep().getClass());
+    }
+
+    @Test
+    public void g_V_not_out() {
+        Assert.assertEquals(g.V().not(__.out().out()), eval("g.V().not(__.out().out())"));
+    }
+
+    @Test
+    public void g_V_not_values() {
+        Assert.assertEquals(g.V().not(__.values("name")), eval("g.V().not(__.values(\"name\"))"));
     }
 }

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/integration/graph/RemoteTestGraph.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/integration/graph/RemoteTestGraph.java
@@ -193,9 +193,9 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 @Graph.OptOut(test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
         method = "g_V_whereXoutXcreatedX_and_outXknowsX_or_inXknowsXX_valuesXnameX",
         reason = "unsupported")
-@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
-        method = "g_V_whereXnotXoutXcreatedXXX_name",
-        reason = "unsupported")
+//@Graph.OptOut(test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
+//        method = "g_V_whereXnotXoutXcreatedXXX_name",
+//        reason = "unsupported")
 @Graph.OptOut(test = "org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest",
         method = "g_V_asXaX_out_asXbX_whereXin_count_isXeqX3XX_or_whereXoutXcreatedX_and_hasXlabel_personXXX_selectXa_bX",
         reason = "unsupported")
@@ -869,9 +869,9 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 //@Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_whereXeqXaXX_name" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be supported")
 //@Graph.OptOut(method="g_V_asXaX_outEXcreatedX_asXbX_inV_asXcX_whereXa_gtXbX_orXeqXbXXX_byXageX_byXweightX_byXweightX_selectXa_cX_byXnameX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be supported")
 //@Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_whereXneqXaXX_name" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be supported")
-@Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXasXbX_outXcreatedX_hasXname_rippleXX_valuesXage_nameX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be supported")
+@Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXasXbX_outXcreatedX_hasXname_rippleXX_valuesXage_nameX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "values('age', 'name') is unsupported")
 //@Graph.OptOut(method="g_VX1X_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_neqXbXX_name" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be supported")
-@Graph.OptOut(method="g_V_asXaX_outXcreatedX_whereXasXaX_name_isXjoshXX_inXcreatedX_name" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be supported")
+//@Graph.OptOut(method="g_V_asXaX_outXcreatedX_whereXasXaX_name_isXjoshXX_inXcreatedX_name" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be supported")
 //@Graph.OptOut(method="g_V_asXaX_outXcreatedX_asXbX_inXcreatedX_asXcX_bothXknowsX_bothXknowsX_asXdX_whereXc__notXeqXaX_orXeqXdXXXX_selectXa_b_c_dX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be supported")
 //@Graph.OptOut(method="g_V_asXaX_outXcreatedX_inXcreatedX_asXbX_whereXa_gtXbXX_byXageX_selectXa_bX_byXnameX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.filter.WhereTest", reason = "will be supported")
 //@Graph.OptOut(method="g_V_hasLabelXpersonX_order_byXageX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.map.OrderTest", reason = "will be supported")
@@ -886,7 +886,7 @@ import org.apache.tinkerpop.gremlin.structure.Graph;
 //@Graph.OptOut(method="g_VX1X_asXaX_outXknowsX_asXbX_selectXa_bX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest", reason = "will be supported")
 @Graph.OptOut(method="g_V_hasXname_isXmarkoXX_asXaX_selectXaX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest", reason = "will be supported")
 @Graph.OptOut(method="g_V_asXaX_name_order_asXbX_selectXa_bX_byXnameX_by_XitX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest", reason = "will be supported")
-@Graph.OptOut(method="g_V_asXaX_whereXoutXknowsXX_selectXaX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest", reason = "will be supported")
+//@Graph.OptOut(method="g_V_asXaX_whereXoutXknowsXX_selectXaX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest", reason = "will be supported")
 @Graph.OptOut(method="g_EX11X_propertiesXweightX_asXaX_selectXaX_byXvalueX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.map.SelectTest", reason = "will be supported")
 //@Graph.OptOut(method="g_VX1X_outE_otherV" , test="org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest", reason = "will be supported")
 @Graph.OptOut(method="g_VX1AsStringX_outXknowsX" , test="org.apache.tinkerpop.gremlin.process.traversal.step.map.VertexTest", reason = "will be supported")


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. support where subtask, i.e. where(out().out()....).
2. support start and end tag nested in where, i.e. where(__.as("a").out()....as("b")), start tag as project type, end tag as where(eq('end_tag')).
3. support not and where(not(..)).
3. treat where(values(..)) / where(select("a").by(..)) / not(values(..)) / not(select("a").by(..)) / where(__.as("a")) as simple filter type, instead of apply.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

