### PR TITLE
preserve order of group entries when parsing results && add fusion st…

### DIFF
--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
@@ -56,6 +56,7 @@ import org.apache.tinkerpop.gremlin.server.op.AbstractEvalOpProcessor;
 import org.apache.tinkerpop.gremlin.server.op.OpProcessorException;
 import org.apache.tinkerpop.gremlin.server.op.standard.StandardOpProcessor;
 import org.apache.tinkerpop.gremlin.structure.Graph;
+import org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.strategy.optimization.TinkerGraphStepStrategy;
 import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
 import org.codehaus.groovy.control.MultipleCompilationErrorsException;
 import org.slf4j.Logger;
@@ -211,6 +212,7 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
         Set<TraversalStrategy<?>> strategies = Utils.getFieldValue(DefaultTraversalStrategies.class,
                 traversalStrategies, "traversalStrategies");
         strategies.clear();
+        strategies.add(TinkerGraphStepStrategy.instance());
         strategies.add(RemoveUselessStepStrategy.instance());
         traversal.asAdmin().applyStrategies();
     }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultProcessor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultProcessor.java
@@ -61,7 +61,7 @@ public class GremlinResultProcessor extends StandardOpProcessor implements Resul
     // format group result as a single map
     protected void formatResultIfNeed() {
         if (resultParser == GremlinResultParserFactory.GROUP) {
-            Map groupResult = new HashMap();
+            Map groupResult = new LinkedHashMap();
             resultCollectors.forEach(k -> {
                 groupResult.putAll((Map) k);
             });


### PR DESCRIPTION
…rategy of scan

<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
1. apply scan fusion strategy, fuse hasLabel() and hasId() with V() or E()
2. preserve order of group entries when parsing results
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

