### PR TITLE
fix optimization of scan fusion

### DIFF
--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/processor/IrStandardOpProcessor.java
@@ -34,6 +34,7 @@ import com.alibaba.graphscope.gremlin.InterOpCollectionBuilder;
 import com.alibaba.graphscope.gremlin.Utils;
 import com.alibaba.graphscope.gremlin.plugin.script.AntlrToJavaScriptEngineFactory;
 import com.alibaba.graphscope.gremlin.plugin.strategy.RemoveUselessStepStrategy;
+import com.alibaba.graphscope.gremlin.plugin.strategy.ScanFusionStepStrategy;
 import com.alibaba.graphscope.gremlin.plugin.traversal.IrCustomizedTraversalSource;
 import com.alibaba.graphscope.gremlin.plugin.traversal.IrCustomizedTraversalSource;
 import com.alibaba.graphscope.gremlin.result.GremlinResultAnalyzer;
@@ -212,7 +213,7 @@ public class IrStandardOpProcessor extends StandardOpProcessor {
         Set<TraversalStrategy<?>> strategies = Utils.getFieldValue(DefaultTraversalStrategies.class,
                 traversalStrategies, "traversalStrategies");
         strategies.clear();
-        strategies.add(TinkerGraphStepStrategy.instance());
+        strategies.add(ScanFusionStepStrategy.instance());
         strategies.add(RemoveUselessStepStrategy.instance());
         traversal.asAdmin().applyStrategies();
     }

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/step/ScanFusionStep.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/step/ScanFusionStep.java
@@ -1,0 +1,98 @@
+package com.alibaba.graphscope.gremlin.plugin.step;
+
+import com.alibaba.graphscope.gremlin.exception.ExtendGremlinStepException;
+import org.apache.tinkerpop.gremlin.process.traversal.Compare;
+import org.apache.tinkerpop.gremlin.process.traversal.Contains;
+import org.apache.tinkerpop.gremlin.process.traversal.P;
+import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.util.AndP;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.T;
+import org.apache.tinkerpop.gremlin.structure.util.StringFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+// fuse global ids and labels with the scan operator
+public class ScanFusionStep<S, E extends Element> extends GraphStep<S, E> implements HasContainerHolder, AutoCloseable {
+    private static final Logger logger = LoggerFactory.getLogger(ScanFusionStep.class);
+    private final List<HasContainer> hasContainers = new ArrayList<>();
+    private final List<String> graphLabels = new ArrayList<>();
+
+    public ScanFusionStep(final GraphStep<S, E> originalGraphStep) {
+        super(originalGraphStep.getTraversal(), originalGraphStep.getReturnClass(), originalGraphStep.isStartStep(), originalGraphStep.getIds());
+        originalGraphStep.getLabels().forEach(this::addLabel);
+    }
+
+    @Override
+    public String toString() {
+        return StringFactory.stepString(this, new Object[]{this.returnClass.getSimpleName().toLowerCase(),
+                Arrays.toString(this.ids), this.graphLabels, this.hasContainers});
+    }
+
+    @Override
+    public List<HasContainer> getHasContainers() {
+        return Collections.unmodifiableList(this.hasContainers);
+    }
+
+    @Override
+    public int hashCode() {
+        return super.hashCode() ^ this.hasContainers.hashCode();
+    }
+
+
+    @Override
+    public void addHasContainer(final HasContainer hasContainer) {
+        if (hasContainer.getPredicate() instanceof AndP) {
+            for (final P<?> predicate : ((AndP<?>) hasContainer.getPredicate()).getPredicates()) {
+                this.addHasContainer(new HasContainer(hasContainer.getKey(), predicate));
+            }
+        } else
+            this.hasContainers.add(hasContainer);
+    }
+
+    public List<String> getGraphLabels() {
+        return Collections.unmodifiableList(this.graphLabels);
+    }
+
+    public void addGraphLabels(String label) {
+        this.graphLabels.add(label);
+    }
+
+    public static boolean processHasLabels(final ScanFusionStep<?, ?> graphStep, final HasContainer hasContainer,
+                                           List<HasContainer> originalContainers) {
+        if (!hasContainer.getKey().equals(T.label.getAccessor()) || graphStep.getIds().length != 0
+                || graphStep.getGraphLabels().size() != 0
+                || hasContainer.getBiPredicate() != Compare.eq && hasContainer.getBiPredicate() != Contains.within) {
+            return false;
+        }
+        if (getContainer(originalContainers, T.id.getAccessor()) != null) {
+            return false;
+        } else {
+            P predicate = hasContainer.getPredicate();
+            if (predicate.getValue() instanceof List && ((List) predicate.getValue()).size() > 0
+                    && ((List) predicate.getValue()).get(0) instanceof String) {
+                List<String> values = (List<String>) predicate.getValue();
+                values.forEach(k -> graphStep.addGraphLabels(k));
+            } else if (predicate.getValue() instanceof String) {
+                graphStep.addGraphLabels((String) predicate.getValue());
+            } else {
+                throw new ExtendGremlinStepException("hasLabel value type not support " + predicate.getValue().getClass());
+            }
+            return true;
+        }
+    }
+
+    public static HasContainer getContainer(List<HasContainer> originalContainers, String key) {
+        for (HasContainer container : originalContainers) {
+            if (container.getKey().equals(key)) return container;
+        }
+        return null;
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/strategy/ScanFusionStepStrategy.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/plugin/strategy/ScanFusionStepStrategy.java
@@ -1,0 +1,49 @@
+package com.alibaba.graphscope.gremlin.plugin.strategy;
+
+import com.alibaba.graphscope.gremlin.plugin.step.ScanFusionStep;
+import org.apache.tinkerpop.gremlin.process.traversal.Step;
+import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
+import org.apache.tinkerpop.gremlin.process.traversal.TraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.step.HasContainerHolder;
+import org.apache.tinkerpop.gremlin.process.traversal.step.filter.HasStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.GraphStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.map.NoOpBarrierStep;
+import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
+import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
+import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
+
+import java.util.List;
+
+public class ScanFusionStepStrategy extends AbstractTraversalStrategy<TraversalStrategy.ProviderOptimizationStrategy> implements TraversalStrategy.ProviderOptimizationStrategy {
+    private static final ScanFusionStepStrategy INSTANCE = new ScanFusionStepStrategy();
+
+    private ScanFusionStepStrategy() {
+    }
+
+    public static ScanFusionStepStrategy instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void apply(Traversal.Admin<?, ?> traversal) {
+        for (final GraphStep originalGraphStep : TraversalHelper.getStepsOfClass(GraphStep.class, traversal)) {
+            final ScanFusionStep<?, ?> scanFusionStep = new ScanFusionStep<>(originalGraphStep);
+            TraversalHelper.replaceStep(originalGraphStep, scanFusionStep, traversal);
+            Step<?, ?> currentStep = scanFusionStep.getNextStep();
+            while (currentStep instanceof HasStep || currentStep instanceof NoOpBarrierStep) {
+                if (currentStep instanceof HasStep) {
+                    List<HasContainer> originalContainers = ((HasContainerHolder) currentStep).getHasContainers();
+                    for (final HasContainer hasContainer : originalContainers) {
+                        if (!GraphStep.processHasContainerIds(scanFusionStep, hasContainer)
+                                && !ScanFusionStep.processHasLabels(scanFusionStep, hasContainer, originalContainers)) {
+                            scanFusionStep.addHasContainer(hasContainer);
+                        }
+                    }
+                    TraversalHelper.copyLabels(currentStep, currentStep.getPreviousStep(), false);
+                    traversal.removeStep(currentStep);
+                }
+                currentStep = currentStep.getNextStep();
+            }
+        }
+    }
+}

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/result/GremlinResultAnalyzer.java
@@ -3,12 +3,12 @@ package com.alibaba.graphscope.gremlin.result;
 import com.alibaba.graphscope.gremlin.Utils;
 import com.alibaba.graphscope.gremlin.exception.UnsupportedStepException;
 import com.alibaba.graphscope.gremlin.plugin.step.PathExpandStep;
+import com.alibaba.graphscope.gremlin.plugin.step.ScanFusionStep;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.step.branch.UnionStep;
 import org.apache.tinkerpop.gremlin.process.traversal.step.filter.*;
 import org.apache.tinkerpop.gremlin.process.traversal.step.map.*;
-import org.apache.tinkerpop.gremlin.tinkergraph.process.traversal.step.sideEffect.TinkerGraphStep;
 
 import java.util.List;
 
@@ -18,7 +18,7 @@ public class GremlinResultAnalyzer {
         GremlinResultParser parserType = GremlinResultParserFactory.GRAPH_ELEMENT;
         for (Step step : steps) {
             if (Utils.equalClass(step, GraphStep.class)
-                    || Utils.equalClass(step, TinkerGraphStep.class) || Utils.equalClass(step, VertexStep.class)
+                    || Utils.equalClass(step, ScanFusionStep.class) || Utils.equalClass(step, VertexStep.class)
                     || Utils.equalClass(step, EdgeVertexStep.class) || Utils.equalClass(step, EdgeOtherVertexStep.class)
                     || Utils.equalClass(step, PathExpandStep.class)) {
                 parserType = GremlinResultParserFactory.GRAPH_ELEMENT;

--- a/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/OpArgTransformFactory.java
+++ b/research/query_service/ir/compiler/src/main/java/com/alibaba/graphscope/gremlin/transform/OpArgTransformFactory.java
@@ -27,6 +27,7 @@ import com.alibaba.graphscope.common.jna.type.FfiNameOrId;
 import com.alibaba.graphscope.common.jna.type.FfiScanOpt;
 import com.alibaba.graphscope.gremlin.Utils;
 import com.alibaba.graphscope.gremlin.InterOpCollectionBuilder;
+import com.alibaba.graphscope.gremlin.plugin.step.ScanFusionStep;
 import org.apache.tinkerpop.gremlin.process.traversal.*;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.IdentityTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.lambda.ValueTraversal;
@@ -63,22 +64,8 @@ public class OpArgTransformFactory {
                 }
             }).collect(Collectors.toList());
 
-    public static Function<List<HasContainer>, List<FfiNameOrId.ByValue>> LABELS_FROM_CONTAINERS = (List<HasContainer> containers) -> {
-        List<String> labels = new ArrayList<>();
-        for (HasContainer container : containers) {
-            if (container.getKey().equals(T.label.getAccessor())) {
-                Object value = container.getValue();
-                if (value instanceof String) {
-                    labels.add((String) value);
-                } else if (value instanceof List
-                        && ((List) value).size() > 0 && ((List) value).get(0) instanceof String) {
-                    labels.addAll((List) value);
-                } else {
-                    throw new OpArgIllegalException(OpArgIllegalException.Cause.UNSUPPORTED_TYPE,
-                            "label should be string or list of string");
-                }
-            }
-        }
+    public static Function<ScanFusionStep, List<FfiNameOrId.ByValue>> LABELS_FROM_STEP = (ScanFusionStep step) -> {
+        List<String> labels = step.getGraphLabels();
         return labels.stream().map(k -> ArgUtils.strAsNameId(k)).collect(Collectors.toList());
     };
 

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/EmptyTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/EmptyTest.java
@@ -18,6 +18,7 @@ package com.alibaba.graphscope.gremlin;
 
 import com.alibaba.graphscope.common.intermediate.operator.ExpandOp;
 import com.alibaba.graphscope.common.intermediate.operator.ScanFusionOp;
+import com.alibaba.graphscope.gremlin.plugin.processor.IrStandardOpProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -35,18 +36,18 @@ public class EmptyTest {
     @Test
     public void g_V_has_no_id_test() {
         Traversal traversal = g.V();
-        traversal.asAdmin().applyStrategies();
+        IrStandardOpProcessor.applyStrategies(traversal);
         Step step = traversal.asAdmin().getStartStep();
-        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.TINKER_GRAPH_STEP.apply(step);
+        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.SCAN_FUSION_STEP.apply(step);
         Assert.assertEquals(false, op.getIds().isPresent());
     }
 
     @Test
     public void g_V_has_no_label_has_no_property_test() {
         Traversal traversal = g.V();
-        traversal.asAdmin().applyStrategies();
+        IrStandardOpProcessor.applyStrategies(traversal);
         Step step = traversal.asAdmin().getStartStep();
-        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.TINKER_GRAPH_STEP.apply(step);
+        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.SCAN_FUSION_STEP.apply(step);
         Assert.assertEquals(false, op.getPredicate().isPresent());
         Assert.assertEquals(false, op.getLabels().isPresent());
     }
@@ -54,9 +55,9 @@ public class EmptyTest {
     @Test
     public void g_V_has_label_has_no_property_test() {
         Traversal traversal = g.V().hasLabel("person");
-        traversal.asAdmin().applyStrategies();
+        IrStandardOpProcessor.applyStrategies(traversal);
         Step step = traversal.asAdmin().getStartStep();
-        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.TINKER_GRAPH_STEP.apply(step);
+        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.SCAN_FUSION_STEP.apply(step);
         Assert.assertEquals(false, op.getPredicate().isPresent());
         Assert.assertEquals(true, op.getLabels().isPresent());
     }
@@ -64,9 +65,9 @@ public class EmptyTest {
     @Test
     public void g_V_has_no_label_has_property_test() {
         Traversal traversal = g.V().has("id", 1);
-        traversal.asAdmin().applyStrategies();
+        IrStandardOpProcessor.applyStrategies(traversal);
         Step step = traversal.asAdmin().getStartStep();
-        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.TINKER_GRAPH_STEP.apply(step);
+        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.SCAN_FUSION_STEP.apply(step);
         Assert.assertEquals(true, op.getPredicate().isPresent());
         Assert.assertEquals(false, op.getLabels().isPresent());
     }
@@ -74,7 +75,7 @@ public class EmptyTest {
     @Test
     public void g_V_outE_has_no_label_test() {
         Traversal traversal = g.V().out();
-        traversal.asAdmin().applyStrategies();
+        IrStandardOpProcessor.applyStrategies(traversal);
         Step step = traversal.asAdmin().getEndStep();
         ExpandOp op = (ExpandOp) StepTransformFactory.VERTEX_STEP.apply(step);
         Assert.assertEquals(false, op.getLabels().isPresent());

--- a/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GraphStepTest.java
+++ b/research/query_service/ir/compiler/src/test/java/com/alibaba/graphscope/gremlin/GraphStepTest.java
@@ -23,6 +23,7 @@ import com.alibaba.graphscope.common.jna.type.FfiAlias;
 import com.alibaba.graphscope.common.jna.type.FfiConst;
 import com.alibaba.graphscope.common.jna.type.FfiNameOrId;
 import com.alibaba.graphscope.common.jna.type.FfiScanOpt;
+import com.alibaba.graphscope.gremlin.plugin.processor.IrStandardOpProcessor;
 import org.apache.tinkerpop.gremlin.process.traversal.Step;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -57,9 +58,9 @@ public class GraphStepTest {
     @Test
     public void g_V_label_test() {
         Traversal traversal = g.V().hasLabel("person");
-        traversal.asAdmin().applyStrategies();
+        IrStandardOpProcessor.applyStrategies(traversal);
         Step graphStep = traversal.asAdmin().getStartStep();
-        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.TINKER_GRAPH_STEP.apply(graphStep);
+        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.SCAN_FUSION_STEP.apply(graphStep);
         FfiNameOrId.ByValue ffiLabel = ((List<FfiNameOrId.ByValue>) op.getLabels().get().applyArg()).get(0);
         Assert.assertEquals("person", ffiLabel.name);
     }
@@ -76,9 +77,9 @@ public class GraphStepTest {
     @Test
     public void g_V_property_test() {
         Traversal traversal = g.V().has("name", "marko");
-        traversal.asAdmin().applyStrategies();
+        IrStandardOpProcessor.applyStrategies(traversal);
         Step graphStep = traversal.asAdmin().getStartStep();
-        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.TINKER_GRAPH_STEP.apply(graphStep);
+        ScanFusionOp op = (ScanFusionOp) StepTransformFactory.SCAN_FUSION_STEP.apply(graphStep);
         String expr = (String) op.getPredicate().get().applyArg();
         Assert.assertEquals("@.name && @.name == \"marko\"", expr);
     }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?
scan fusion strategy:
1. g.V().hasLabel() -> hasLabel is set to table.
2. g.V().hasLabel().hasId() -> hasId is set to index_predicate, label is set to filtering by property key.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

