### PR TITLE
[IR Runtime] Support Max, Min, ToSet, CountDistinct in Accumulator

### DIFF
--- a/research/query_service/ir/runtime/src/process/operator/accum/accum.rs
+++ b/research/query_service/ir/runtime/src/process/operator/accum/accum.rs
@@ -263,6 +263,9 @@ impl Decode for RecordAccumulator {
 #[cfg(test)]
 mod tests {
 
+    use std::borrow::BorrowMut;
+    use std::cmp::Ordering;
+
     use ir_common::generated::algebra as pb;
     use ir_common::generated::common as common_pb;
     use pegasus::api::{Fold, Sink};
@@ -493,6 +496,9 @@ mod tests {
             if let Some(entry) = record.get(Some(&"a".into())) {
                 fold_result = entry.as_ref().clone();
             }
+        }
+        if let Entry::Collection(collection) = fold_result.borrow_mut() {
+            collection.sort_by(|v1, v2| v1.partial_cmp(&v2).unwrap_or(Ordering::Equal));
         }
         assert_eq!(fold_result, expected_result);
     }

--- a/research/query_service/ir/runtime/src/process/operator/accum/accumulator.rs
+++ b/research/query_service/ir/runtime/src/process/operator/accum/accumulator.rs
@@ -13,12 +13,16 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
+use std::cmp::Ordering;
+use std::collections::HashSet;
 use std::fmt::Debug;
+use std::hash::Hash;
 use std::io;
+use std::ops::Add;
 
 use pegasus::codec::{Decode, Encode, ReadExt, WriteExt};
 
-use crate::error::FnExecResult;
+use crate::error::{FnExecError, FnExecResult};
 
 pub trait Accumulator<I, O>: Send + Debug {
     fn accum(&mut self, next: I) -> FnExecResult<()>;
@@ -108,5 +112,192 @@ impl<D: Decode> Decode for ToList<D> {
     fn read_from<R: ReadExt>(reader: &mut R) -> io::Result<Self> {
         let inner = <Vec<D>>::read_from(reader)?;
         Ok(ToList { inner })
+    }
+}
+
+#[derive(Clone)]
+pub struct ToSet<D: Eq + Hash> {
+    pub inner: HashSet<D>,
+}
+
+unsafe impl<D: Send + Eq + Hash> Send for ToSet<D> {}
+
+impl<D: Debug + Eq + Hash> Debug for ToSet<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self.inner)
+    }
+}
+
+impl<D: Debug + Eq + Hash + Send + 'static> Accumulator<D, Vec<D>> for ToSet<D> {
+    fn accum(&mut self, next: D) -> FnExecResult<()> {
+        self.inner.insert(next);
+        Ok(())
+    }
+
+    fn finalize(&mut self) -> FnExecResult<Vec<D>> {
+        let mut result = Vec::with_capacity(self.inner.len());
+        let set = std::mem::replace(&mut self.inner, HashSet::new());
+        result.extend(set.into_iter());
+        Ok(result)
+    }
+}
+
+impl<D: Encode + Eq + Hash> Encode for ToSet<D> {
+    fn write_to<W: WriteExt>(&self, writer: &mut W) -> io::Result<()> {
+        writer.write_u32(self.inner.len() as u32)?;
+        for data in self.inner.iter() {
+            data.write_to(writer)?;
+        }
+        Ok(())
+    }
+}
+
+impl<D: Decode + Eq + Hash> Decode for ToSet<D> {
+    fn read_from<R: ReadExt>(reader: &mut R) -> io::Result<Self> {
+        let len = reader.read_u32()?;
+        let mut inner = HashSet::with_capacity(len as usize);
+        for _ in 0..len {
+            let data = <D>::read_from(reader)?;
+            inner.insert(data);
+        }
+        Ok(ToSet { inner })
+    }
+}
+
+#[derive(Clone)]
+pub struct Maximum<D> {
+    pub max: Option<D>,
+}
+
+impl<D: Debug> Debug for Maximum<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "max={:?}", self.max)
+    }
+}
+
+unsafe impl<D: Send> Send for Maximum<D> {}
+
+impl<D: Debug + Send + PartialOrd + 'static> Accumulator<D, Option<D>> for Maximum<D> {
+    fn accum(&mut self, next: D) -> FnExecResult<()> {
+        if let Some(pre) = self.max.take() {
+            match &pre.partial_cmp(&next) {
+                Some(Ordering::Less) => {
+                    self.max = Some(next);
+                }
+                Some(Ordering::Equal) => self.max = Some(pre),
+                Some(Ordering::Greater) => self.max = Some(pre),
+                None => Err(FnExecError::accum_error("Data cannot be compared in Maximum Accumulator"))?,
+            }
+        } else {
+            self.max = Some(next);
+        }
+        Ok(())
+    }
+
+    fn finalize(&mut self) -> FnExecResult<Option<D>> {
+        Ok(self.max.take())
+    }
+}
+
+impl<D: Encode> Encode for Maximum<D> {
+    fn write_to<W: WriteExt>(&self, writer: &mut W) -> io::Result<()> {
+        self.max.write_to(writer)?;
+        Ok(())
+    }
+}
+
+impl<D: Decode> Decode for Maximum<D> {
+    fn read_from<R: ReadExt>(reader: &mut R) -> io::Result<Self> {
+        let max = <Option<D>>::read_from(reader)?;
+        Ok(Maximum { max })
+    }
+}
+
+#[derive(Clone)]
+pub struct Minimum<D> {
+    pub min: Option<D>,
+}
+
+impl<D: Debug> Debug for Minimum<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "min={:?}", self.min)
+    }
+}
+
+unsafe impl<D: Send> Send for Minimum<D> {}
+
+impl<D: Debug + Send + PartialOrd + 'static> Accumulator<D, Option<D>> for Minimum<D> {
+    fn accum(&mut self, next: D) -> FnExecResult<()> {
+        if let Some(pre) = self.min.take() {
+            match &pre.partial_cmp(&next) {
+                Some(Ordering::Less) => {
+                    self.min = Some(pre);
+                }
+                Some(Ordering::Equal) => self.min = Some(pre),
+                Some(Ordering::Greater) => self.min = Some(next),
+                None => Err(FnExecError::accum_error("Data cannot be compared in Minimum Accumulator"))?,
+            }
+        } else {
+            self.min = Some(next);
+        }
+        Ok(())
+    }
+
+    fn finalize(&mut self) -> FnExecResult<Option<D>> {
+        Ok(self.min.take())
+    }
+}
+
+impl<D: Encode> Encode for Minimum<D> {
+    fn write_to<W: WriteExt>(&self, writer: &mut W) -> io::Result<()> {
+        self.min.write_to(writer)?;
+        Ok(())
+    }
+}
+
+impl<D: Decode> Decode for Minimum<D> {
+    fn read_from<R: ReadExt>(reader: &mut R) -> io::Result<Self> {
+        let min = <Option<D>>::read_from(reader)?;
+        Ok(Minimum { min })
+    }
+}
+
+#[derive(Clone)]
+pub struct DataSum<D> {
+    pub seed: Option<D>,
+}
+
+impl<D: Debug> Debug for DataSum<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "sum={:?}", self.seed)
+    }
+}
+
+impl<D: Send + Debug + Add<Output = D> + 'static> Accumulator<D, Option<D>> for DataSum<D> {
+    fn accum(&mut self, next: D) -> FnExecResult<()> {
+        if let Some(seed) = self.seed.take() {
+            self.seed = Some(seed.add(next));
+        } else {
+            self.seed = Some(next);
+        }
+        Ok(())
+    }
+
+    fn finalize(&mut self) -> FnExecResult<Option<D>> {
+        Ok(self.seed.take())
+    }
+}
+
+impl<D: Encode> Encode for DataSum<D> {
+    fn write_to<W: WriteExt>(&self, writer: &mut W) -> io::Result<()> {
+        self.seed.write_to(writer)?;
+        Ok(())
+    }
+}
+
+impl<D: Decode> Decode for DataSum<D> {
+    fn read_from<R: ReadExt>(reader: &mut R) -> io::Result<Self> {
+        let seed = <Option<D>>::read_from(reader)?;
+        Ok(DataSum { seed })
     }
 }

--- a/research/query_service/ir/runtime/src/process/operator/accum/accumulator.rs
+++ b/research/query_service/ir/runtime/src/process/operator/accum/accumulator.rs
@@ -177,9 +177,9 @@ impl<D: Debug> Debug for Maximum<D> {
 unsafe impl<D: Send> Send for Maximum<D> {}
 
 impl<D: Debug + Send + PartialOrd + 'static> Accumulator<D, Option<D>> for Maximum<D> {
-    fn accum(&mut self, mut next: D) -> FnExecResult<()> {
+    fn accum(&mut self, next: D) -> FnExecResult<()> {
         if let Some(pre) = self.max.as_mut() {
-            if pre < &mut next {
+            if (pre as &D) < &next {
                 *pre = next;
             }
         } else {
@@ -221,9 +221,9 @@ impl<D: Debug> Debug for Minimum<D> {
 unsafe impl<D: Send> Send for Minimum<D> {}
 
 impl<D: Debug + Send + PartialOrd + 'static> Accumulator<D, Option<D>> for Minimum<D> {
-    fn accum(&mut self, mut next: D) -> FnExecResult<()> {
+    fn accum(&mut self, next: D) -> FnExecResult<()> {
         if let Some(pre) = self.min.as_mut() {
-            if pre > &mut next {
+            if (pre as &D) > &next {
                 *pre = next;
             }
         } else {

--- a/research/query_service/ir/runtime/src/process/operator/group/group.rs
+++ b/research/query_service/ir/runtime/src/process/operator/group/group.rs
@@ -381,4 +381,66 @@ mod tests {
         }
         assert_eq!(group_result, expected_result);
     }
+
+    // g.V().group().by("name").by(values('age').min()) with key as 'a', value as 'b'
+    #[test]
+    fn group_min_test() {
+        let function = pb::group_by::AggFunc {
+            vars: vec![common_pb::Variable::from("@.age".to_string())],
+            aggregate: 1, // min
+            alias: Some(NameOrId::Str("b".to_string()).into()),
+        };
+        let key_alias = pb::group_by::KeyAlias {
+            key: Some(common_pb::Variable::from("@.name".to_string())),
+            alias: Some(NameOrId::Str("a".to_string()).into()),
+        };
+        let group_opr_pb = pb::GroupBy { mappings: vec![key_alias], functions: vec![function] };
+        let mut result = group_test(group_opr_pb);
+        let mut group_result = HashSet::new();
+        let expected_result: HashSet<(Entry, Entry)> = [
+            (CommonObject::Prop("vadas".into()).into(), CommonObject::Prop(object!(27)).into()),
+            (CommonObject::Prop("marko".into()).into(), CommonObject::Prop(object!(27)).into()),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        while let Some(Ok(result)) = result.next() {
+            let key = result.get(Some(&"a".into())).unwrap().as_ref();
+            let val = result.get(Some(&"b".into())).unwrap().as_ref();
+            group_result.insert((key.clone(), val.clone()));
+        }
+        assert_eq!(group_result, expected_result);
+    }
+
+    // g.V().group().by("name").by(values('age').max()) with key as 'a', value as 'b'
+    #[test]
+    fn group_max_test() {
+        let function = pb::group_by::AggFunc {
+            vars: vec![common_pb::Variable::from("@.age".to_string())],
+            aggregate: 2, // max
+            alias: Some(NameOrId::Str("b".to_string()).into()),
+        };
+        let key_alias = pb::group_by::KeyAlias {
+            key: Some(common_pb::Variable::from("@.name".to_string())),
+            alias: Some(NameOrId::Str("a".to_string()).into()),
+        };
+        let group_opr_pb = pb::GroupBy { mappings: vec![key_alias], functions: vec![function] };
+        let mut result = group_test(group_opr_pb);
+        let mut group_result = HashSet::new();
+        let expected_result: HashSet<(Entry, Entry)> = [
+            (CommonObject::Prop("marko".into()).into(), CommonObject::Prop(object!(29)).into()),
+            (CommonObject::Prop("vadas".into()).into(), CommonObject::Prop(object!(27)).into()),
+        ]
+        .iter()
+        .cloned()
+        .collect();
+
+        while let Some(Ok(result)) = result.next() {
+            let key = result.get(Some(&"a".into())).unwrap().as_ref();
+            let val = result.get(Some(&"b".into())).unwrap().as_ref();
+            group_result.insert((key.clone(), val.clone()));
+        }
+        assert_eq!(group_result, expected_result);
+    }
 }


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. Support Max, Min, ToSet, CountDistinct in Accumulator. i.e., we support fold/group with these accum types.
2. Add uts for accumulators of Max, Min, ToSet, CountDistinct.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

