### PR TITLE
[IR Runtime] IR TagOpt for more compact structure in Runtime

### DIFF
--- a/research/query_service/ir/core/src/plan/ffi.rs
+++ b/research/query_service/ir/core/src/plan/ffi.rs
@@ -595,7 +595,8 @@ pub extern "C" fn init_logical_plan() -> *const c_void {
         if let Some(schema) = &meta.schema {
             plan.meta = plan
                 .meta
-                .with_store_conf(schema.is_table_id(), schema.is_column_id());
+                .with_store_conf(schema.is_table_id(), schema.is_column_id())
+                .with_tag_id();
         }
     }
     Box::into_raw(plan) as *const c_void

--- a/research/query_service/ir/core/src/plan/meta.rs
+++ b/research/query_service/ir/core/src/plan/meta.rs
@@ -624,6 +624,14 @@ impl PlanMeta {
         }
     }
 
+    pub fn get_tag_ids(&self) -> Vec<(NameOrId, u32)> {
+        self.tag_ids
+            .clone()
+            .into_iter()
+            .map(|x| x)
+            .collect()
+    }
+
     pub fn set_curr_node(&mut self, curr_node: u32) {
         self.curr_node = CurrNodeOpt::Single(curr_node);
     }

--- a/research/query_service/ir/integrated/tests/apply_test.rs
+++ b/research/query_service/ir/integrated/tests/apply_test.rs
@@ -217,7 +217,7 @@ mod test {
     fn apply_inner_join(worker_num: u32) {
         initialize();
         // join_kind: InnerJoin
-        let request = init_apply_count_request(0, "a".into());
+        let request = init_apply_count_request(0, TAG_A.into());
         let mut results = submit_query(request, worker_num);
         let mut result_collection = vec![];
         let v1: DefaultId = LDBCVertexParser::to_global_id(1, 0);
@@ -238,7 +238,7 @@ mod test {
                         // This should be CommonObject::Count(cnt).
                         // We assume it as CommonObject::Prop(cnt) here since we parse it as CommonObject::Prop in parse_result()
                         if let Entry::Element(RecordElement::OffGraph(CommonObject::Prop(cnt))) = record
-                            .get(Some(&"a".to_string().into()))
+                            .get(Some(&TAG_A.into()))
                             .unwrap()
                             .as_ref()
                         {
@@ -272,7 +272,7 @@ mod test {
     fn apply_left_out_join(worker_num: u32) {
         initialize();
         // join_kind: LeftOuterJoin
-        let request = init_apply_count_request(1, "a".into());
+        let request = init_apply_count_request(1, TAG_A.into());
         let mut results = submit_query(request, worker_num);
         let mut result_collection = vec![];
         let v1: DefaultId = LDBCVertexParser::to_global_id(1, 0);
@@ -288,14 +288,14 @@ mod test {
                         record.get(None).unwrap().as_ref()
                     {
                         if let Entry::Element(RecordElement::OffGraph(CommonObject::Prop(cnt))) = record
-                            .get(Some(&"a".to_string().into()))
+                            .get(Some(&TAG_A.into()))
                             .unwrap()
                             .as_ref()
                         {
                             result_collection
                                 .push((vertex.id() as DefaultId, Some(cnt.clone().as_u64().unwrap())));
                         } else if let Entry::Element(RecordElement::OffGraph(CommonObject::None)) = record
-                            .get(Some(&"a".to_string().into()))
+                            .get(Some(&TAG_A.into()))
                             .unwrap()
                             .as_ref()
                         {

--- a/research/query_service/ir/integrated/tests/auxilia_test.rs
+++ b/research/query_service/ir/integrated/tests/auxilia_test.rs
@@ -60,10 +60,8 @@ mod test {
             alias: None,
         };
 
-        let auxilia_opr = pb::Auxilia {
-            params: Some(query_params(vec![], vec![], None)),
-            alias: Some("a".to_string().into()),
-        };
+        let auxilia_opr =
+            pb::Auxilia { params: Some(query_params(vec![], vec![], None)), alias: Some(TAG_A.into()) };
 
         let conf = JobConf::new("auxilia_simple_alias_test");
         let mut result = pegasus::run(conf, || {
@@ -84,7 +82,7 @@ mod test {
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
             if let Some(element) = record
-                .get(Some(&"a".to_string().into()))
+                .get(Some(&TAG_A.into()))
                 .unwrap()
                 .as_graph_vertex()
             {
@@ -157,7 +155,7 @@ mod test {
 
         let auxilia_opr = pb::Auxilia {
             params: Some(query_params(vec![], vec!["name".into()], None)),
-            alias: Some("a".to_string().into()),
+            alias: Some(TAG_A.into()),
         };
 
         let conf = JobConf::new("auxilia_get_property_with_none_tag_input_test");
@@ -179,7 +177,7 @@ mod test {
         let mut result_ids_with_prop = vec![];
         while let Some(Ok(record)) = result.next() {
             if let Some(element) = record
-                .get(Some(&NameOrId::Str("a".to_string())))
+                .get(Some(&TAG_A.into()))
                 .unwrap()
                 .as_graph_vertex()
             {
@@ -271,7 +269,7 @@ mod test {
                 vec!["name".into()],
                 str_to_expr_pb("@.name==\"vadas\"".to_string()).ok(),
             )),
-            alias: Some("a".to_string().into()),
+            alias: Some(TAG_A.into()),
         };
 
         let conf = JobConf::new("auxilia_alias_test");
@@ -293,7 +291,7 @@ mod test {
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
             if let Some(element) = record
-                .get(Some(&NameOrId::Str("a".to_string())))
+                .get(Some(&TAG_A.into()))
                 .unwrap()
                 .as_graph_vertex()
             {

--- a/research/query_service/ir/integrated/tests/expand_test.rs
+++ b/research/query_service/ir/integrated/tests/expand_test.rs
@@ -220,20 +220,20 @@ mod test {
     fn expand_outv_from_tag_as_tag_test() {
         let query_param = query_params(vec!["knows".into()], vec![], None);
         let expand_opr_pb = pb::EdgeExpand {
-            v_tag: Some("a".into()),
+            v_tag: Some(TAG_A.into()),
             direction: 0,
             params: Some(query_param),
             is_edge: false,
-            alias: Some("b".into()),
+            alias: Some(TAG_B.into()),
         };
-        let mut result = expand_test_with_source_tag("a".into(), expand_opr_pb);
+        let mut result = expand_test_with_source_tag(TAG_A.into(), expand_opr_pb);
         let mut result_ids = vec![];
         let v2: DefaultId = LDBCVertexParser::to_global_id(2, 0);
         let v4: DefaultId = LDBCVertexParser::to_global_id(4, 0);
         let mut expected_ids = vec![v2, v4];
         while let Some(Ok(record)) = result.next() {
             if let Some(element) = record
-                .get(Some(&"b".into()))
+                .get(Some(&TAG_B.into()))
                 .unwrap()
                 .as_graph_vertex()
             {
@@ -251,7 +251,7 @@ mod test {
         let query_param = query_params(vec!["knows".into()], vec![], None);
         let project = pb::Project {
             mappings: vec![pb::project::ExprAlias {
-                expr: str_to_expr_pb("@a".to_string()).ok(),
+                expr: Some(to_expr_var_pb(Some(TAG_A.into()), None)),
                 alias: None,
             }],
             is_append: false,
@@ -269,7 +269,7 @@ mod test {
             let project = project.clone();
             let expand = expand.clone();
             |input, output| {
-                let mut stream = input.input_from(source_gen(Some("a".into())))?;
+                let mut stream = input.input_from(source_gen(Some(TAG_A.into())))?;
                 let map_func = project.gen_map().unwrap();
                 stream = stream.map(move |input| map_func.exec(input))?;
                 let flatmap_func = expand.gen_flat_map().unwrap();

--- a/research/query_service/ir/integrated/tests/graph_query_test.rs
+++ b/research/query_service/ir/integrated/tests/graph_query_test.rs
@@ -138,7 +138,7 @@ mod test {
     fn init_get_property_after_shuffle_request() -> JobRequest {
         let source_opr = pb::Scan {
             scan_opt: 0,
-            alias: Some("a".into()),
+            alias: Some(TAG_A.into()),
             params: Some(query_params_all_columns(vec![], vec![], None)),
             idx_predicate: None,
         };
@@ -153,7 +153,7 @@ mod test {
 
         let project_opr = pb::Project {
             mappings: vec![pb::project::ExprAlias {
-                expr: Some(str_to_expr_pb("@a.~all".to_string()).unwrap()),
+                expr: Some(to_expr_var_all_prop_pb(Some(TAG_A.into()))),
                 alias: None,
             }],
             is_append: true,

--- a/research/query_service/ir/integrated/tests/match_test.rs
+++ b/research/query_service/ir/integrated/tests/match_test.rs
@@ -28,7 +28,7 @@ mod test {
     use pegasus_server::JobRequest;
     use runtime::graph::element::GraphElement;
 
-    use crate::common::test::{initialize, parse_result, query_params, submit_query};
+    use crate::common::test::{initialize, parse_result, query_params, submit_query, TAG_A, TAG_B, TAG_C};
 
     // g.V().hasLabel("person").match(
     //    __.as('a').has(age, gt(25)).out("created").as('b'),
@@ -65,27 +65,27 @@ mod test {
         let pattern = pb::Pattern {
             sentences: vec![
                 pb::pattern::Sentence {
-                    start: Some("a".into()),
+                    start: Some(TAG_A.into()),
                     binders: vec![pb::pattern::Binder {
                         item: Some(pb::pattern::binder::Item::Edge(out_knows)),
                     }],
-                    end: Some("b".into()),
+                    end: Some(TAG_B.into()),
                     join_kind: 0,
                 },
                 pb::pattern::Sentence {
-                    start: Some("a".into()),
+                    start: Some(TAG_A.into()),
                     binders: vec![pb::pattern::Binder {
                         item: Some(pb::pattern::binder::Item::Edge(out_created.clone())),
                     }],
-                    end: Some("c".into()),
+                    end: Some(TAG_C.into()),
                     join_kind: 0,
                 },
                 pb::pattern::Sentence {
-                    start: Some("b".into()),
+                    start: Some(TAG_B.into()),
                     binders: vec![pb::pattern::Binder {
                         item: Some(pb::pattern::binder::Item::Edge(out_created.clone())),
                     }],
-                    end: Some("c".into()),
+                    end: Some(TAG_C.into()),
                     join_kind: 0,
                 },
             ],
@@ -93,9 +93,9 @@ mod test {
 
         let sink = pb::Sink {
             tags: vec![
-                common_pb::NameOrIdKey { key: Some("a".into()) },
-                common_pb::NameOrIdKey { key: Some("b".into()) },
-                common_pb::NameOrIdKey { key: Some("c".into()) },
+                common_pb::NameOrIdKey { key: Some(TAG_A.into()) },
+                common_pb::NameOrIdKey { key: Some(TAG_B.into()) },
+                common_pb::NameOrIdKey { key: Some(TAG_C.into()) },
             ],
             id_name_mappings: vec![],
         };
@@ -130,15 +130,15 @@ mod test {
                 Ok(res) => {
                     let entry = parse_result(res).unwrap();
                     let a = entry
-                        .get(Some(&"a".into()))
+                        .get(Some(&TAG_A.into()))
                         .unwrap()
                         .as_graph_vertex();
                     let b = entry
-                        .get(Some(&"b".into()))
+                        .get(Some(&TAG_B.into()))
                         .unwrap()
                         .as_graph_vertex();
                     let c = entry
-                        .get(Some(&"c".into()))
+                        .get(Some(&TAG_C.into()))
                         .unwrap()
                         .as_graph_vertex();
                     result_collection.push((a.unwrap().id(), b.unwrap().id(), c.unwrap().id()));

--- a/research/query_service/ir/proto/algebra.proto
+++ b/research/query_service/ir/proto/algebra.proto
@@ -371,6 +371,7 @@ message Sink {
       ENTITY = 0;
       RELATION = 1;
       COLUMN = 2;
+      TAG = 3;
   }
   message IdNameMapping {
     int32 id = 1;

--- a/research/query_service/ir/runtime/Cargo.toml
+++ b/research/query_service/ir/runtime/Cargo.toml
@@ -13,6 +13,7 @@ pegasus_common = { path = "../../../engine/pegasus/common" }
 pegasus = { path = "../../../engine/pegasus/pegasus" }
 pegasus_server = { path = "../../../engine/pegasus/server-v0" }
 prost = "0.9"
+vec_map = "0.8.2"
 
 [features]
 default = []

--- a/research/query_service/ir/runtime/src/process/operator/flatmap/edge_expand.rs
+++ b/research/query_service/ir/runtime/src/process/operator/flatmap/edge_expand.rs
@@ -16,7 +16,7 @@
 use std::convert::TryInto;
 
 use ir_common::generated::algebra as algebra_pb;
-use ir_common::NameOrId;
+use ir_common::KeyId;
 use pegasus::api::function::{DynIter, FlatMapFunction, FnResult};
 
 use crate::error::{FnExecError, FnGenError, FnGenResult};
@@ -26,8 +26,8 @@ use crate::process::operator::flatmap::FlatMapFuncGen;
 use crate::process::record::{Record, RecordExpandIter, RecordPathExpandIter};
 
 pub struct EdgeExpandOperator<E: Into<GraphObject>> {
-    start_v_tag: Option<NameOrId>,
-    edge_or_end_v_tag: Option<NameOrId>,
+    start_v_tag: Option<KeyId>,
+    edge_or_end_v_tag: Option<KeyId>,
     stmt: Box<dyn Statement<ID, E>>,
 }
 

--- a/research/query_service/ir/runtime/src/process/operator/group/fold.rs
+++ b/research/query_service/ir/runtime/src/process/operator/group/fold.rs
@@ -16,7 +16,7 @@
 use std::convert::TryInto;
 
 use ir_common::generated::algebra as algebra_pb;
-use ir_common::NameOrId;
+use ir_common::KeyId;
 use pegasus::api::function::{FnResult, MapFunction};
 use pegasus_server::pb as server_pb;
 
@@ -60,7 +60,7 @@ impl FoldGen<u64, Record> for algebra_pb::GroupBy {
 
 #[derive(Debug)]
 struct CountAlias {
-    alias: Option<NameOrId>,
+    alias: Option<KeyId>,
 }
 
 impl MapFunction<u64, Record> for CountAlias {
@@ -80,7 +80,7 @@ mod tests {
     use pegasus_server::pb as server_pb;
 
     use crate::process::functions::FoldGen;
-    use crate::process::operator::tests::init_source;
+    use crate::process::operator::tests::{init_source, TAG_A};
     use crate::process::record::{CommonObject, Entry, Record, RecordElement};
 
     fn count_test(source: Vec<Record>, fold_opr_pb: pb::GroupBy) -> ResultStream<Record> {
@@ -135,13 +135,13 @@ mod tests {
         let function = pb::group_by::AggFunc {
             vars: vec![common_pb::Variable::from("@".to_string())],
             aggregate: 3, // count
-            alias: Some("a".into()),
+            alias: Some(TAG_A.into()),
         };
         let fold_opr_pb = pb::GroupBy { mappings: vec![], functions: vec![function] };
         let mut result = count_test(init_source(), fold_opr_pb);
         let mut cnt = 0;
         if let Some(Ok(record)) = result.next() {
-            if let Some(entry) = record.get(Some(&"a".into())) {
+            if let Some(entry) = record.get(Some(&TAG_A.into())) {
                 cnt = match entry.as_ref() {
                     Entry::Element(RecordElement::OffGraph(CommonObject::Count(cnt))) => *cnt,
                     _ => {

--- a/research/query_service/ir/runtime/src/process/operator/map/auxilia.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/auxilia.rs
@@ -16,7 +16,7 @@
 use std::convert::TryInto;
 
 use ir_common::generated::algebra as algebra_pb;
-use ir_common::NameOrId;
+use ir_common::KeyId;
 use pegasus::api::function::{FilterMapFunction, FnResult};
 
 use crate::error::{FnExecError, FnGenResult};
@@ -31,7 +31,7 @@ use crate::process::record::{Entry, Record};
 #[derive(Debug)]
 struct AuxiliaOperator {
     query_params: QueryParams,
-    alias: Option<NameOrId>,
+    alias: Option<KeyId>,
 }
 
 impl FilterMapFunction<Record, Record> for AuxiliaOperator {

--- a/research/query_service/ir/runtime/src/process/operator/map/get_v.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/get_v.rs
@@ -17,7 +17,7 @@ use std::convert::TryInto;
 
 use ir_common::generated::algebra as algebra_pb;
 use ir_common::generated::algebra::get_v::VOpt;
-use ir_common::NameOrId;
+use ir_common::KeyId;
 use pegasus::api::function::{FnResult, MapFunction};
 
 use crate::error::{FnExecError, FnGenResult};
@@ -28,9 +28,9 @@ use crate::process::record::Record;
 
 #[derive(Debug)]
 struct GetVertexOperator {
-    start_tag: Option<NameOrId>,
+    start_tag: Option<KeyId>,
     opt: VOpt,
-    alias: Option<NameOrId>,
+    alias: Option<KeyId>,
 }
 
 impl MapFunction<Record, Record> for GetVertexOperator {

--- a/research/query_service/ir/runtime/src/process/operator/map/path_end.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/path_end.rs
@@ -16,7 +16,7 @@
 use std::convert::TryInto;
 
 use ir_common::generated::algebra as algebra_pb;
-use ir_common::NameOrId;
+use ir_common::KeyId;
 use pegasus::api::function::{FnResult, MapFunction};
 
 use crate::error::{FnExecError, FnGenResult};
@@ -25,7 +25,7 @@ use crate::process::record::Record;
 
 #[derive(Debug)]
 struct PathEndOperator {
-    alias: Option<NameOrId>,
+    alias: Option<KeyId>,
 }
 
 impl MapFunction<Record, Record> for PathEndOperator {

--- a/research/query_service/ir/runtime/src/process/operator/map/path_start.rs
+++ b/research/query_service/ir/runtime/src/process/operator/map/path_start.rs
@@ -16,7 +16,7 @@
 use std::convert::TryInto;
 
 use ir_common::generated::algebra as algebra_pb;
-use ir_common::NameOrId;
+use ir_common::KeyId;
 use pegasus::api::function::{FnResult, MapFunction};
 
 use crate::error::{FnExecError, FnGenResult};
@@ -26,7 +26,7 @@ use crate::process::record::Record;
 
 #[derive(Debug)]
 struct PathStartOperator {
-    start_tag: Option<NameOrId>,
+    start_tag: Option<KeyId>,
     is_whole_path: bool,
 }
 

--- a/research/query_service/ir/runtime/src/process/operator/shuffle.rs
+++ b/research/query_service/ir/runtime/src/process/operator/shuffle.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use ir_common::error::ParsePbError;
 use ir_common::generated::common as common_pb;
-use ir_common::NameOrId;
+use ir_common::KeyId;
 use pegasus::api::function::{FnResult, RouteFunction};
 
 use crate::error::FnExecError;
@@ -29,7 +29,7 @@ use crate::process::record::Record;
 pub struct RecordRouter {
     p: Arc<dyn Partitioner>,
     num_workers: usize,
-    shuffle_key: Option<NameOrId>,
+    shuffle_key: Option<KeyId>,
 }
 
 impl RecordRouter {

--- a/research/query_service/ir/runtime/src/process/operator/sink/sink.rs
+++ b/research/query_service/ir/runtime/src/process/operator/sink/sink.rs
@@ -13,6 +13,7 @@
 //! See the License for the specific language governing permissions and
 //! limitations under the License.
 
+use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use std::convert::TryInto;
 use std::ops::Deref;
@@ -22,7 +23,7 @@ use ir_common::generated::algebra as algebra_pb;
 use ir_common::generated::algebra::sink::MetaType;
 use ir_common::generated::common as common_pb;
 use ir_common::generated::results as result_pb;
-use ir_common::NameOrId;
+use ir_common::{KeyId, NameOrId};
 use pegasus::api::function::{FnResult, MapFunction};
 
 use crate::error::FnGenResult;
@@ -33,9 +34,9 @@ use crate::process::record::{CommonObject, Entry, Record, RecordElement};
 #[derive(Debug)]
 pub struct RecordSinkEncoder {
     /// the given column tags to sink;
-    sink_keys: Vec<Option<NameOrId>>,
+    sink_keys: Vec<Option<KeyId>>,
     /// A map from id to name; including type of Entity (Vertex in Graph Database),
-    /// Relation (Edge in Graph Database) and Column (Property in Graph Database)
+    /// Relation (Edge in Graph Database), Column (Property in Graph Database), and Tag (Alias).
     schema_map: Option<HashMap<(MetaType, i32), String>>,
 }
 
@@ -77,7 +78,8 @@ impl RecordSinkEncoder {
             RecordElement::OffGraph(o) => match o {
                 CommonObject::None => Some(result_pb::element::Inner::Object(Object::None.into())),
                 CommonObject::Prop(obj) | CommonObject::Agg(obj) => {
-                    Some(result_pb::element::Inner::Object(obj.clone().into()))
+                    let obj_pb = self.object_to_pb(obj.clone());
+                    Some(result_pb::element::Inner::Object(obj_pb))
                 }
                 CommonObject::Count(cnt) => {
                     let item = if *cnt <= (i64::MAX as u64) {
@@ -93,19 +95,50 @@ impl RecordSinkEncoder {
         result_pb::Element { inner }
     }
 
-    fn label_to_pb(&self, label: NameOrId, t: MetaType) -> common_pb::NameOrId {
-        let mapped_label = if let Some(schema_map) = self.schema_map.as_ref() {
-            match label {
-                NameOrId::Str(_) => label,
-                NameOrId::Id(id) => {
-                    let str_label = schema_map.get(&(t, id)).unwrap();
-                    NameOrId::Str(str_label.clone())
+    fn object_to_pb(&self, value: Object) -> common_pb::Value {
+        if let Object::KV(kv) = value {
+            let mut pairs: Vec<common_pb::Pair> = Vec::with_capacity(kv.len());
+            for (mut key, val) in kv {
+                // a special case to parse key in KV, where the key is vec![tag, prop_name]
+                if let Object::Vector(ref mut v) = key {
+                    if v.len() == 2 {
+                        if let Ok(tag_id) = v.get(0).unwrap().as_i32() {
+                            let mapped_tag = Object::from(self.get_meta_name(tag_id, MetaType::Tag));
+                            *(v[0].borrow_mut()) = mapped_tag;
+                        }
+                        if let Ok(prop_id) = v.get(1).unwrap().as_i32() {
+                            let mapped_prop = Object::from(self.get_meta_name(prop_id, MetaType::Column));
+                            *(v[1].borrow_mut()) = mapped_prop;
+                        }
+                    }
                 }
+                let key_pb: common_pb::Value = key.into();
+                let val_pb: common_pb::Value = val.into();
+                pairs.push(common_pb::Pair { key: Some(key_pb), val: Some(val_pb) })
             }
+            let item = common_pb::value::Item::PairArray(common_pb::PairArray { item: pairs });
+            common_pb::Value { item: Some(item) }
         } else {
-            label
+            common_pb::Value::from(value)
+        }
+    }
+
+    fn meta_to_pb(&self, meta: NameOrId, t: MetaType) -> common_pb::NameOrId {
+        let mapped_meta = match meta {
+            NameOrId::Str(_) => meta,
+            NameOrId::Id(id) => self.get_meta_name(id, t),
         };
-        mapped_label.into()
+        mapped_meta.into()
+    }
+
+    fn get_meta_name(&self, meta_id: KeyId, t: MetaType) -> NameOrId {
+        if let Some(schema_map) = self.schema_map.as_ref() {
+            if let Some(meta_name) = schema_map.get(&(t, meta_id)) {
+                return NameOrId::Str(meta_name.clone());
+            }
+        }
+        // if we can not find mapped meta_name, we return meta_id.to_string() instead.
+        NameOrId::Str(meta_id.to_string())
     }
 
     fn vertex_to_pb(&self, v: &Vertex) -> result_pb::Vertex {
@@ -113,7 +146,7 @@ impl RecordSinkEncoder {
             id: v.id() as i64,
             label: v
                 .label()
-                .map(|label| self.label_to_pb(label.clone(), MetaType::Entity)),
+                .map(|label| self.meta_to_pb(label.clone(), MetaType::Entity)),
             // TODO: return detached vertex without property for now
             properties: vec![],
         }
@@ -124,15 +157,15 @@ impl RecordSinkEncoder {
             id: e.id() as i64,
             label: e
                 .label()
-                .map(|label| self.label_to_pb(label.clone(), MetaType::Relation)),
+                .map(|label| self.meta_to_pb(label.clone(), MetaType::Relation)),
             src_id: e.src_id as i64,
             src_label: e
                 .get_src_label()
-                .map(|label| self.label_to_pb(label.clone(), MetaType::Entity)),
+                .map(|label| self.meta_to_pb(label.clone(), MetaType::Entity)),
             dst_id: e.dst_id as i64,
             dst_label: e
                 .get_dst_label()
-                .map(|label| self.label_to_pb(label.clone(), MetaType::Entity)),
+                .map(|label| self.meta_to_pb(label.clone(), MetaType::Entity)),
             // TODO: return detached edge without property for now
             properties: vec![],
         }
@@ -182,7 +215,7 @@ impl MapFunction<Record, result_pb::Results> for RecordSinkEncoder {
                 let column_pb = result_pb::Column {
                     name_or_id: sink_key
                         .clone()
-                        .map(|sink_key| common_pb::NameOrId::from(sink_key.clone())),
+                        .map(|sink_key| self.meta_to_pb(NameOrId::Id(sink_key), MetaType::Tag)),
                     entry: Some(entry_pb),
                 };
                 sink_columns.push(column_pb);

--- a/research/query_service/ir/runtime/src/process/operator/sort/sort.rs
+++ b/research/query_service/ir/runtime/src/process/operator/sort/sort.rs
@@ -94,7 +94,7 @@ mod tests {
     use crate::graph::element::{Element, GraphElement, Vertex};
     use crate::graph::property::{DefaultDetails, Details, DynDetails};
     use crate::process::operator::sort::CompareFunctionGen;
-    use crate::process::operator::tests::{init_source, init_source_with_tag};
+    use crate::process::operator::tests::{init_source, init_source_with_tag, to_var_pb, TAG_A};
     use crate::process::record::Record;
 
     fn sort_test(source: Vec<Record>, sort_opr: pb::OrderBy) -> ResultStream<Record> {
@@ -240,7 +240,7 @@ mod tests {
     fn sort_by_tag_test() {
         let sort_opr = pb::OrderBy {
             pairs: vec![pb::order_by::OrderingPair {
-                key: Some(common_pb::Variable::from("@a".to_string())),
+                key: Some(to_var_pb(Some(TAG_A.into()), None)),
                 order: 2, // descending
             }],
             limit: None,
@@ -249,7 +249,7 @@ mod tests {
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
             if let Some(element) = record
-                .get(Some(&"a".into()))
+                .get(Some(&TAG_A.into()))
                 .unwrap()
                 .as_graph_vertex()
             {
@@ -265,7 +265,7 @@ mod tests {
     fn sort_by_tag_property_test() {
         let sort_opr = pb::OrderBy {
             pairs: vec![pb::order_by::OrderingPair {
-                key: Some(common_pb::Variable::from("@a.age".to_string())),
+                key: Some(to_var_pb(Some(TAG_A.into()), Some("age".into()))),
                 order: 2, // descending
             }],
             limit: None,
@@ -274,7 +274,7 @@ mod tests {
         let mut result_ids = vec![];
         while let Some(Ok(record)) = result.next() {
             if let Some(element) = record
-                .get(Some(&"a".into()))
+                .get(Some(&TAG_A.into()))
                 .unwrap()
                 .as_graph_vertex()
             {

--- a/research/query_service/ir/runtime/src/process/operator/source.rs
+++ b/research/query_service/ir/runtime/src/process/operator/source.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use ir_common::error::{ParsePbError, ParsePbResult};
 use ir_common::generated::algebra as algebra_pb;
-use ir_common::NameOrId;
+use ir_common::KeyId;
 
 use crate::error::{FnGenError, FnGenResult};
 use crate::graph::element::{Edge, Vertex};
@@ -40,7 +40,7 @@ pub enum SourceType {
 pub struct SourceOperator {
     query_params: QueryParams,
     src: Option<HashMap<u64, Vec<ID>>>,
-    alias: Option<NameOrId>,
+    alias: Option<KeyId>,
     source_type: SourceType,
 }
 
@@ -155,7 +155,7 @@ impl TryFrom<algebra_pb::Scan> for SourceOperator {
         };
         let alias = scan_pb
             .alias
-            .map(|alias| NameOrId::try_from(alias))
+            .map(|alias| KeyId::try_from(alias))
             .transpose()?;
 
         let query_params = QueryParams::try_from(scan_pb.params)?;

--- a/research/query_service/ir/runtime/src/process/operator/subtask/apply.rs
+++ b/research/query_service/ir/runtime/src/process/operator/subtask/apply.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 
 use ir_common::generated::algebra as algebra_pb;
 use ir_common::generated::algebra::join::JoinKind;
-use ir_common::NameOrId;
+use ir_common::KeyId;
 use pegasus::api::function::{BinaryFunction, FnResult};
 
 use crate::error::{FnExecError, FnGenError, FnGenResult};
@@ -28,7 +28,7 @@ use crate::process::record::{CommonObject, Entry, Record};
 #[derive(Debug)]
 struct ApplyOperator {
     join_kind: JoinKind,
-    alias: Option<NameOrId>,
+    alias: Option<KeyId>,
 }
 
 impl BinaryFunction<Record, Vec<Record>, Option<Record>> for ApplyOperator {
@@ -46,7 +46,7 @@ impl BinaryFunction<Record, Vec<Record>, Option<Record>> for ApplyOperator {
                     if let Some(alias) = self.alias.as_ref() {
                         // append sub_entry without moving head
                         let columns = parent.get_columns_mut();
-                        columns.insert(alias.clone(), sub_entry.clone());
+                        columns.insert(*alias as usize, sub_entry.clone());
                     } else {
                         parent.append_arc_entry(sub_entry.clone(), None);
                     }
@@ -58,7 +58,7 @@ impl BinaryFunction<Record, Vec<Record>, Option<Record>> for ApplyOperator {
                     let entry: Arc<Entry> = Arc::new((CommonObject::None).into());
                     if let Some(alias) = self.alias.as_ref() {
                         let columns = parent.get_columns_mut();
-                        columns.insert(alias.clone(), entry.clone());
+                        columns.insert(*alias as usize, entry.clone());
                     } else {
                         parent.append_arc_entry(entry.clone(), None);
                     }
@@ -71,7 +71,7 @@ impl BinaryFunction<Record, Vec<Record>, Option<Record>> for ApplyOperator {
                         .ok_or(FnExecError::get_tag_error("get entry of subtask result failed"))?;
                     if let Some(alias) = self.alias.as_ref() {
                         let columns = parent.get_columns_mut();
-                        columns.insert(alias.clone(), sub_entry.clone());
+                        columns.insert(*alias as usize, sub_entry.clone());
                     } else {
                         parent.append_arc_entry(sub_entry.clone(), None);
                     }
@@ -98,7 +98,7 @@ impl ApplyGen<Record, Vec<Record>, Option<Record>> for algebra_pb::Apply {
         let alias = self
             .alias
             .as_ref()
-            .map(|tag_pb| NameOrId::try_from(tag_pb.clone()))
+            .map(|tag_pb| KeyId::try_from(tag_pb.clone()))
             .transpose()?;
         match join_kind {
             JoinKind::Inner | JoinKind::LeftOuter | JoinKind::Semi | JoinKind::Anti => {}


### PR DESCRIPTION
<!--
Thanks for your contribution! please review https://github.com/alibaba/GraphScope/blob/main/CONTRIBUTING.md before opening an issue.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. Use KeyId for all tags in Runtime for more compact Record structure.
2. Add TagMeta processing in Sink Op (in Proto, IR-Core and Runtime).
3. Fix all related CI tests.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes

